### PR TITLE
Re-order the build.

### DIFF
--- a/training-slides/build.sh
+++ b/training-slides/build.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-echo "Building slides"
-RUST_LOG=debug mdslides --template ${SCRIPT_DIR}/template.html --output-dir ${SCRIPT_DIR}/slides --mdbook-path ${SCRIPT_DIR} --index-template ${SCRIPT_DIR}/index-template.html
+# Build the book first, because mdbook will create any empty sections
 echo "Building book"
 RUST_LOG=info mdbook build ${SCRIPT_DIR}
+# Then build the slides
+echo "Building slides"
+RUST_LOG=debug mdslides --template ${SCRIPT_DIR}/template.html --output-dir ${SCRIPT_DIR}/slides --mdbook-path ${SCRIPT_DIR} --index-template ${SCRIPT_DIR}/index-template.html
+# Then run the tests (which is slow)
 echo "Testing book"
 RUST_LOG=info mdbook test ${SCRIPT_DIR}


### PR DESCRIPTION
If you build the mdbook first, non-existent chapters get created as empty files. If you build the slides first, non-existent chapters crash the build.