### PR TITLE
Clean up imports-and-modules.

### DIFF
--- a/training-slides/src/good-design-practices.md
+++ b/training-slides/src/good-design-practices.md
@@ -117,14 +117,14 @@ println!("{:?}", tp);
 2. `a == b` means `b == a`
 3. `a == b` and `b == c` means `a == c`
 
-IEEE 754 floating point numbers (`f32` and `f64`) break the first rule (`NAN == NAN` is always false). They are `PartialEq` and not `Eq`.
+IEEE 754 floating point numbers (`f32` and `f64`) break the first rule (`NaN == NaN` is always false). They are `PartialEq` and not `Eq`.
 
 ## `PartialOrd` and `Ord`
 
 * Same as `PartialEq` and `Eq`, but they also allow other comparisons (`<`, `<=`, `>=`, `>`).
 * Generally, everything is `Ord`, except `f32` and `f64`.
 * Characters are compared by their code point numerical values
-* Arrays and slices are compared element by element. Length act as a tiebreaker.
+* Arrays and slices are compared element by element. Length acts as a tiebreaker.
     * `"aaa" < "b"`, but `"aaa" > "a"`
     * elements themselves have to be `PartialOrd` or `Ord`
 

--- a/training-slides/src/imports-and-modules.md
+++ b/training-slides/src/imports-and-modules.md
@@ -15,38 +15,7 @@
 * A crate is the unit of Rust software suitable for shipping.
 * Yes, it's a deliberate pun.
 * The Rust Standard Library is a crate.
-
-## Kinds of Crates
-
-* Library crates (has a `src/lib.rs`)
-* Binary crates (has e.g. a `src/main.rs`)
-
-Note:
-
-A package can have multiple binary crates, e.g. `src/bin/foo.rs` and `src/bin/bar.rs` and you use `cargo run --bin foo` to pick between them.
-
-You can also put the binary crates in `src/examples`, where they should act as examples of how to use your library.
-
-A package can even contain both a library and some binaries. But never more than one library, and it can never contain nothing.
-
-## Libraries
-
-A library cannot be 'executed'. It can only be included into another crate.
-
-## Binaries
-
-A binary crate can be executed on the command-line.
-
-```console
-$ cargo new --bin hello
-     Created binary (application) `hello` package
-$ cd hello 
-$ cargo run
-   Compiling hello v0.1.0 (/private/tmp/hello)
-    Finished dev [unoptimized + debuginfo] target(s) in 2.46s
-     Running `target/debug/hello`
-Hello, world!
-```
+* Binary Crates and Library Crates
 
 ## There's no build file
 
@@ -85,6 +54,78 @@ Note:
 
 Prelude modules, like `std::io::prelude`, usually contain important traits and you usually want to import all of it with a `*` wildcard.
 
+## In-line modules
+
+You can declare a module in-line:
+
+```rust
+mod animals {
+    pub struct Cat { name: String }
+
+    impl Cat {
+        pub fn new(name: &str) -> Cat {
+            Cat { name: name.to_owned() }
+        }
+    }
+}
+
+fn main() {
+    let c = animals::Cat::new("Mittens");
+    // let c = animals::Cat { name: "Mittens" };
+}
+```
+
+## Modules in a file
+
+You can also put modules in their own file on disk.
+
+This will load from either `./animals/mod.rs` or `./animals.rs`:
+
+```rust ignore
+mod animals;
+
+fn main() {
+    let c = animals::Cat::new("Mittens");
+    // let c = animals::Cat { name: "Mittens" };
+}
+```
+
+## Modules can be nested...
+
+```console
+~/probe-run $ tree src
+src
+├── backtrace
+│   ├── mod.rs
+│   ├── pp.rs
+│   ├── symbolicate.rs
+│   └── unwind.rs
+├── canary.rs
+├── cli.rs
+├── cortexm.rs
+├── dep
+│   ├── cratesio.rs
+│   ├── mod.rs
+│   ├── rust_repo.rs
+│   ├── rust_std
+│   │   └── toolchain.rs
+│   ├── rust_std.rs
+│   └── rustc.rs
+├── elf.rs
+├── main.rs
+├── probe.rs
+├── registers.rs
+├── stacked.rs
+└── target_info.rs
+```
+
+Note:
+
+The choice about `foo.rs` vs `foo/mod.rs` often depends on whether `mod foo`
+itself has any child modules.
+
+The example is from the Knurling tool [`probe-run`](https://github.com/knurling-rs/probe-run).
+
 ## What kind of import?
 
 Choosing whether to import the parent module, or each of the types contained within, is something of an art form.
@@ -108,38 +149,3 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 ```
-
-## Comments
-
-* The Rust Standard Library docs come from `cargo doc` on the libstd source code
-* You should add `/// Hello` comments to every public item
-* Ideally you would add `/// Hello` comments to *every* item
-
-```rust []
-/// Parses the input string as a 32-bit unsigned integer.
-/// Will panic if the input is not a valid integer.
-pub fn parse(input: &str) -> u32 {
-    todo!()
-}
-```
-
-## Doc Comments
-
-You can even embed code-snippets in your comments.
-
-```rust []
-/// Parses the input string as a 32-bit unsigned integer.
-/// Will panic if the input is not a valid integer.
-///
-/// ```
-/// let x = parse("123");
-/// assert_eq(x, 123);
-/// ```
-pub fn parse(input: &str) -> u32 {
-    todo!()
-}
-```
-
-Note:
-
-For example, <https://doc.rust-lang.org/std/fs/struct.File.html#examples>.


### PR DESCRIPTION
* Remove some overlap with Good Design Practices
* Add notes on mod foo; vs mod foo { }
* Fix some typos in good-design-practices

Closes: #78
Closes: #61 