### PR TITLE
fix markdown nits

### DIFF
--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -6,81 +6,81 @@
 
 # Rust Fundamentals
 
--   [Overview](./overview.md)
--   [Installation](./installation.md)
--   [Basic Types](./basic-types.md)
--   [Control Flow](./control-flow.md)
--   [Compound Types](./compound-types.md)
--   [Ownership and Borrowing](./ownership.md)
--   [Error Handling](./error-handling.md)
--   [Collections](./collections.md)
--   [Iterators](./iterators.md)
--   [Imports and Modules](./imports-and-modules.md)
--   [Good Design Practices](./good-design-practices.md)
+- [Overview](./overview.md)
+- [Installation](./installation.md)
+- [Basic Types](./basic-types.md)
+- [Control Flow](./control-flow.md)
+- [Compound Types](./compound-types.md)
+- [Ownership and Borrowing](./ownership.md)
+- [Error Handling](./error-handling.md)
+- [Collections](./collections.md)
+- [Iterators](./iterators.md)
+- [Imports and Modules](./imports-and-modules.md)
+- [Good Design Practices](./good-design-practices.md)
 
 # Applied Rust
 
 Using Rust on Windows/macOS/Linux. Requires [Rust Fundamentals](#rust-fundamentals).
 
--   [Methods and Traits](./methods-traits.md)
--   [Rust I/O Traits](./io.md)
--   [Generics](./generics.md)
--   [Lifetimes](./lifetimes.md)
--   [Cargo Workspaces](./cargo-workspaces.md)
--   [Heap Allocation (Box and Rc)](./heap.md)
--   [Shared Mutability (Cell, RefCell)](./shared-mutability.md)
--   [Thread Safety (Send/Sync, Arc, Mutex)](./thread-safety.md)
--   [Closures and the Fn/FnOnce/FnMut traits](./closures.md)
--   [Spawning Threads and Scoped Threads](./spawning-threads.md)
+- [Methods and Traits](./methods-traits.md)
+- [Rust I/O Traits](./io.md)
+- [Generics](./generics.md)
+- [Lifetimes](./lifetimes.md)
+- [Cargo Workspaces](./cargo-workspaces.md)
+- [Heap Allocation (Box and Rc)](./heap.md)
+- [Shared Mutability (Cell, RefCell)](./shared-mutability.md)
+- [Thread Safety (Send/Sync, Arc, Mutex)](./thread-safety.md)
+- [Closures and the Fn/FnOnce/FnMut traits](./closures.md)
+- [Spawning Threads and Scoped Threads](./spawning-threads.md)
 
 # Advanced Rust
 
 Topics that go beyond [Applied Rust](#applied-rust).
 
--   [Advanced Strings](./advanced-strings.md)
--   [Debugging Rust](./debugging-rust.md)
--   [Dependency Management with Cargo](./dependency-management.md)
--   [Deref Coercions](./deref-coercions.md)
--   [Design Patterns](./design-patterns.md)
--   [Documentation](./documentation.md)
--   [Drop, Panic and Abort](./drop-panic-abort.md)
--   [Dynamic Dispatch](./dynamic-dispatch.md)
--   [Macros](./macros.md)
--   [Property Testing](./property-testing.md)
--   [Rust Projects Build Time](./rust-build-time.md)
--   [Send and Sync](./send-and-sync.md)
--   [Serde](./serde.md)
--   [Testing](./testing.md)
--   [The stdlib](./std-lib-tour.md)
--   [Using Cargo](./using-cargo.md)
--   [Using Types to encode State (TBC)](./type-state.md)
--   [WASM](./wasm.md)
+- [Advanced Strings](./advanced-strings.md)
+- [Debugging Rust](./debugging-rust.md)
+- [Dependency Management with Cargo](./dependency-management.md)
+- [Deref Coercions](./deref-coercions.md)
+- [Design Patterns](./design-patterns.md)
+- [Documentation](./documentation.md)
+- [Drop, Panic and Abort](./drop-panic-abort.md)
+- [Dynamic Dispatch](./dynamic-dispatch.md)
+- [Macros](./macros.md)
+- [Property Testing](./property-testing.md)
+- [Rust Projects Build Time](./rust-build-time.md)
+- [Send and Sync](./send-and-sync.md)
+- [Serde](./serde.md)
+- [Testing](./testing.md)
+- [The stdlib](./std-lib-tour.md)
+- [Using Cargo](./using-cargo.md)
+- [Using Types to encode State (TBC)](./type-state.md)
+- [WASM](./wasm.md)
 
 # No-Std Rust
 
 Rust for the Linux Kernel and other no-std environments with an pre-existing C API. Requires [Applied Rust](#applied-rust).
 
--   [Overview of no-std Rust (TBC)](./rust-no-std.md)
--   [Unsafe Rust](./unsafe.md)
--   [Foreign Function Interface](./ffi.md)
--   [Working with Nightly](./working-with-nighly.md)
--   [Rust in the Linux Kernel (TBC)](./rust-linux-kernel.md)
--   [Rust on an RTOS (TBC)](./rust-rtos.md)
--   [Writing a new target (TBC)](./custom-target.md)
+- [Overview of no-std Rust (TBC)](./rust-no-std.md)
+- [Unsafe Rust](./unsafe.md)
+- [Foreign Function Interface](./ffi.md)
+- [Working with Nightly](./working-with-nighly.md)
+- [Rust in the Linux Kernel (TBC)](./rust-linux-kernel.md)
+- [Rust on an RTOS (TBC)](./rust-rtos.md)
+- [Writing a new target (TBC)](./custom-target.md)
 
 # Bare-Metal Rust
 
 Topics about using Rust on ARM Cortex-M Microcontrollers (and similar). Requires [Low-Level Rust](#low-level-rust).
 
--   [Overview of Bare-Metal Rust (TBC)](./rust-bare-metal.md)
--   [Booting a Cortex-M Microcontroller (TBC)](./cortex-m-booting.md)
--   [Execptions and Interrupts on a Cortex-M Microcontroller (TBC)](./cortex-m-exceptions-interrupts.md)
--   [PACs and svd2rust (TBC)](./pac-svd2rust.md)
--   [The Embedded HAL and its implementations (TBC)](./embedded-hals.md)
--   [Using RTIC v1 (TBC)](./rtic-v1.md)
+- [Overview of Bare-Metal Rust (TBC)](./rust-bare-metal.md)
+- [Booting a Cortex-M Microcontroller (TBC)](./cortex-m-booting.md)
+- [Execptions and Interrupts on a Cortex-M Microcontroller (TBC)](./cortex-m-exceptions-interrupts.md)
+- [PACs and svd2rust (TBC)](./pac-svd2rust.md)
+- [The Embedded HAL and its implementations (TBC)](./embedded-hals.md)
+- [Using RTIC v1 (TBC)](./rtic-v1.md)
 
 # Ferrocene
 
 Topics around [Ferrocene](https://ferrous-systems.com/ferrocene/), the qualified toolchain for writing safety-critical systems in Rust.
 
--   [Installing and Using Ferrocene (TBC)](./installing-using-ferrocene.md)
+- [Installing and Using Ferrocene (TBC)](./installing-using-ferrocene.md)

--- a/training-slides/src/advanced-strings.md
+++ b/training-slides/src/advanced-strings.md
@@ -8,9 +8,9 @@ Most common are `String` and `&str`.
 
 ## `String`
 
--   *Owns* the data it stores, and can be mutated freely
--   The bytes it points at exist on the *heap*
--   Does not implement `Copy`, but implements `Clone`
+- *Owns* the data it stores, and can be mutated freely
+- The bytes it points at exist on the *heap*
+- Does not implement `Copy`, but implements `Clone`
 
 ```mermaid
 flowchart LR
@@ -22,9 +22,8 @@ flowchart LR
 
 ## `&str`
 
--   A "string slice reference" (or just "string slice")
--   Usually only seen as a borrowed value
--   The bytes it points at may be anywhere: heap, stack, or in read-only memory
+- A "string slice reference" (or just "string slice")
+- The bytes it points at may be anywhere: heap, stack, or in read-only memory
 
 ```mermaid
 flowchart LR
@@ -64,9 +63,9 @@ fn main() {
 
 ## When to Use What?
 
--   `String` is the *easiest* to use when starting out. Refine later.
--   `String` owns its data, so works well as a field of a `struct` or `enum`.
--   `&str` is typically used in function arguments.
+- `String` is the *easiest* to use when starting out. Refine later.
+- `String` owns its data, so works well as a field of a `struct` or `enum`.
+- `&str` is typically used in function arguments.
 
 ## `Deref` Coercion
 
@@ -85,9 +84,8 @@ This is because `String` s implement `Deref<Target=str>` .
 
 ## Exotic String types
 
--   `OsStr` and `OsString` may show up when working with file systems or system calls.
-
--   `CStr` and `CString` may show up when working with FFI.
+- `OsStr` and `OsString` may show up when working with file systems or system calls.
+- `CStr` and `CString` may show up when working with FFI.
 
 The differences between `[Os|C]Str` and `[Os|C]String` are generally the same as the normal types.
 
@@ -97,9 +95,9 @@ These types represent *platform native* strings. This is necessary because Unix 
 
 ## Behind the `OsString` Scenes
 
--   Unix strings are often arbitrary non-zero 8-bit sequences, usually interpreted as UTF-8.
--   Windows strings are often arbitrary non-zero 16-bit sequences, usually interpreted as UTF-16.
--   Rust strings are always valid UTF-8, and may contain `NUL` bytes.
+- Unix strings are often arbitrary non-zero 8-bit sequences, usually interpreted as UTF-8.
+- Windows strings are often arbitrary non-zero 16-bit sequences, usually interpreted as UTF-16.
+- Rust strings are always valid UTF-8, and may contain `NUL` bytes.
 
 `OsString` and `OsStr` bridge this gap and allow for conversion to and from `String` and `str`.
 
@@ -123,7 +121,7 @@ fn main() {
 }
 ```
 
-## Common String Tasks
+## Common String Tasks 2
 
 Concatenation:
 
@@ -136,7 +134,7 @@ fn main() {
 }
 ```
 
-## Common String Tasks
+## Common String Tasks 3
 
 Replacing:
 
@@ -166,10 +164,10 @@ fn main() {
 
 ## Raw String Literals
 
--   Starts with `r` followed by zero or more `#` followed by `"`
--   Ends with `"` followed by the same number of `#`
--   Can span multiple lines, leading spaces become part of the line
--   Escape sequences are not processed
+- Starts with `r` followed by zero or more `#` followed by `"`
+- Ends with `"` followed by the same number of `#`
+- Can span multiple lines, leading spaces become part of the line
+- Escape sequences are not processed
 
 ```rust []
 fn main () {
@@ -185,8 +183,8 @@ fn main () {
 
 ## Byte String Literals
 
-* not really strings
-* used to declare static byte slices (have a `&[u8]` type)
+- not really strings
+- used to declare static byte slices (have a `&[u8]` type)
 
 ```rust []
 fn main() {

--- a/training-slides/src/basic-types.md
+++ b/training-slides/src/basic-types.md
@@ -4,11 +4,11 @@
 
 Rust comes with all standard int types, with and without sign
 
--   `i8`, `u8`
--   `i16`, `u16`
--   `i32`, `u32`
--   `i64`, `u64`
--   `i128`, `u128`
+- `i8`, `u8`
+- `i16`, `u16`
+- `i32`, `u32`
+- `i64`, `u64`
+- `i128`, `u128`
 
 ## Syntactic clarity in specifying numbers
 
@@ -24,7 +24,7 @@ let x = b'a';      // A single u8
 
 Rust comes with two architecture-dependent number types:
 
--   `isize`, `usize`
+- `isize`, `usize`
 
 ## Casts
 
@@ -65,9 +65,9 @@ Boolean in Rust is represented by either of two values: `true` or
 
 `char` is a [Unicode Scalar Value](https://www.unicode.org/glossary/#unicode_scalar_value) being represented as a "single character"
 
--   A literal in single quotes: `'r'`
--   Four (4) bytes in size
--   More than just ASCII: glyphs, emoji, accented characters, etc.
+- A literal in single quotes: `'r'`
+- Four (4) bytes in size
+- More than just ASCII: glyphs, emoji, accented characters, etc.
 
 ## Character Literals
 
@@ -84,7 +84,7 @@ fn main() {
 }
 ```
 
-## Character Literals
+## Character Literals 2
 
 ```rust,ignore
 fn main() {
@@ -95,8 +95,8 @@ fn main() {
 
 ## Arrays
 
-* Arrays have multiple elements of the same type.
-* They are of fixed size (it's part of the type).
+- Arrays have multiple elements of the same type.
+- They are of fixed size (it's part of the type).
 
 ```rust
 fn main() {
@@ -106,9 +106,9 @@ fn main() {
 
 ## Slices
 
-* Slices are like arrays, but with a run-time specified size.
-* Slices carry a pointer to some other array, and a length.
-* Slices cannot be resized but can be subsliced.
+- Slices are like arrays, but with a run-time specified size.
+- Slices carry a pointer to some other array, and a length.
+- Slices cannot be resized but can be subsliced.
 
 ```rust [2|3]
 fn main() {
@@ -124,10 +124,10 @@ Note:
 
 ## String Slices
 
-* Strings Slices (`&str`) are a special kind of `&[u8]`
-* They are *guaranteed* to be a valid UTF-8 encoded Unicode string
-* It is *undefined behaviour* to create one that isn't valid UTF-8
-* Slicing must be done on *character boundaries*
+- Strings Slices (`&str`) are a special kind of `&[u8]`
+- They are *guaranteed* to be a valid UTF-8 encoded Unicode string
+- It is *undefined behaviour* to create one that isn't valid UTF-8
+- Slicing must be done on *character boundaries*
 
 ```rust []
 fn main() {

--- a/training-slides/src/cargo-workspaces.md
+++ b/training-slides/src/cargo-workspaces.md
@@ -1,6 +1,6 @@
 # Cargo Workspaces
 
-## Cargo Workspaces
+## Cargo Workspaces 🚚
 
 Allow you to split your project into several packages
 
@@ -96,6 +96,7 @@ EOF
 ```
 
 Example:
+
 ```bash
 nw spaceship
 cargo new --lib spaceship/packages/fuel-control

--- a/training-slides/src/closures.md
+++ b/training-slides/src/closures.md
@@ -13,7 +13,7 @@ Note:
 * Instances of Fn can be called repeatedly without mutating state.
 * `Fn` (a trait) and `fn` (a function pointer) are different!
 
-## These traits are implemented by:
+## These traits are implemented by
 
 * Function Pointers
 * Closures
@@ -31,7 +31,7 @@ fn main() {
 }
 ```
 
-## Closures
+## Closures 2
 
 * Defined with `|<args>|`
 * Most basic kind, are just function pointers
@@ -127,7 +127,7 @@ fn setup_teardown<F, T>(f: F) -> T where F: FnOnce(&mut Vec<u32>) -> T {
 }
 ```
 
-## Cleaning up
+## Cleaning up 2
 
 ```rust []
 fn setup_teardown<F, T>(f: F) -> T where F: FnOnce(&mut Vec<u32>) -> T {

--- a/training-slides/src/collections.md
+++ b/training-slides/src/collections.md
@@ -18,7 +18,7 @@ flowchart LR
     array("[1, 2, 3, 4, 5]")
 ```
 
-## Building the array at runtime.
+## Building the array at runtime
 
 How do you know how many 'slots' you've used?
 
@@ -98,7 +98,7 @@ Note:
 
 The dark blue block of data is heap allocated.
 
-## There's a macro short-cut too...
+## There's a macro short-cut too!
 
 ```rust
 fn main() {
@@ -262,7 +262,7 @@ fn main() {
 * Can access any element (`queue[i]`) quickly
 * Can push/pop from the front or back easily
 
-## Downsides of Vec
+## Downsides of Vec 2
 
 * Cannot borrow it as a single `&[T]` slice without moving items around
 * Not great for insertion in the middle

--- a/training-slides/src/compound-types.md
+++ b/training-slides/src/compound-types.md
@@ -15,7 +15,7 @@ struct Point {
 
 ## Construction
 
--   there is no partial initialization
+- there is no partial initialization
 
 ```rust [1-4|6-8]
 struct Point {
@@ -28,9 +28,9 @@ fn main() {
 }
 ```
 
-## Construction
+## Construction 2
 
--   but you can copy from an existing variable of the same type
+- but you can copy from an existing variable of the same type
 
 ```rust [8]
 struct Point {
@@ -61,8 +61,8 @@ fn main() {
 
 ## Tuples
 
--   Holds values of different types together.
--   Like an anonymous `struct`, with fields numbered 0, 1, etc.
+- Holds values of different types together.
+- Like an anonymous `struct`, with fields numbered 0, 1, etc.
 
 ```rust [2|3-4]
 fn main() {
@@ -74,9 +74,9 @@ fn main() {
 
 ## `()`
 
--   the *empty tuple*
--   represents the absence of data
--   we often use this similarly to how you’d use `void` in C
+- the *empty tuple*
+- represents the absence of data
+- we often use this similarly to how you’d use `void` in C
 
 ```rust
 fn prints_but_returns_nothing(data: &str) -> () {
@@ -86,7 +86,7 @@ fn prints_but_returns_nothing(data: &str) -> () {
 
 ## Tuple Structs
 
--   Like a `struct`, with fields numbered 0, 1, etc.
+- Like a `struct`, with fields numbered 0, 1, etc.
 
 ```rust [1|4|5-6]
 struct Point(i32,i32);
@@ -100,8 +100,8 @@ fn main() {
 
 ## Enums
 
--   An `enum` represents different variations of the same subject.
--   The different choices in an enum are called *variants*
+- An `enum` represents different variations of the same subject.
+- The different choices in an enum are called *variants*
 
 <!--
 -   stress that enums are an "either or" type: you can only have one
@@ -141,15 +141,15 @@ fn main() {
 }
 ```
 
-## Enums with Values
+## Enums with Values 2
 
--   An enum is the same size, no matter which variant is picked
--   It will be the size of the largest variant
+- An enum is the same size, no matter which variant is picked
+- It will be the size of the largest variant
 
 ## Doing a `match` on an `enum`
 
--   When an `enum` has variants, you use `match` to extract the data
--   New variables are created from the *pattern* (e.g. `radius`)
+- When an `enum` has variants, you use `match` to extract the data
+- New variables are created from the *pattern* (e.g. `radius`)
 
 ```rust [1-4|7-14|8|11]
 enum Shape {
@@ -169,10 +169,10 @@ fn check_shape(shape: &Shape) {
 }
 ```
 
-## Doing a `match` on an `enum`
+## Doing a `match` on an `enum` 2
 
--   There are two variables called `radius`
--   The later one hides the earlier one
+- There are two variables called `radius`
+- The later one hides the earlier one
 
 ```rust [7|9]
 enum Shape {
@@ -221,7 +221,7 @@ You might ask "Why is there a `*` in front of `radius` in `match`?" - It's becau
 
 ## Combining patterns
 
--   You can use the `|` operator to join patterns together
+- You can use the `|` operator to join patterns together
 
 ```rust [1-16|9]
 enum Shape {
@@ -244,8 +244,8 @@ fn test_shape(shape: &Shape) {
 
 ## Shorthand: `if let` conditionals
 
--   You can use `if let` if only one case is of interest.
--   Still *pattern matching*
+- You can use `if let` if only one case is of interest.
+- Still *pattern matching*
 
 ```rust []
 enum Shape {
@@ -262,8 +262,8 @@ fn test_shape(shape: &Shape) {
 
 ## Shorthand: `let else` conditionals
 
--   If you expect it to match, but want to handle the error...
--   The `else` block must *diverge*
+- If you expect it to match, but want to handle the error...
+- The `else` block must *diverge*
 
 ```rust []
 enum Shape {
@@ -282,7 +282,7 @@ fn test_shape(shape: &Shape) {
 
 ## Shorthand: `while let` conditionals
 
--   Keep looping whilst the pattern still matches
+- Keep looping whilst the pattern still matches
 
 ```rust should_panic []
 enum Shape {
@@ -318,4 +318,3 @@ enum Result<T, E> {
 ```
 
 We'll come back to them after we learn about error handling.
-

--- a/training-slides/src/control-flow.md
+++ b/training-slides/src/control-flow.md
@@ -122,39 +122,6 @@ fn main() {
     }
 ```
 
-## Foreshadowing! Pattern Matching with bindings 👻
-
-`match` is extremely powerful, we'll come back to it.
-
-```rust ignore
-enum Pets {
-    Dog(String),
-    Cat(String),
-}
-
-fn test_pet(pet: Pets) {
-    match pet {
-        Pets::Cat(cat_name) => println!("Cat name is {}", cat_name),
-        Pets::Dog(dog_name) => println!("Dog name is {}", dog_name), 
-        //          👆 New binding `dog_name` now exists for this match arm!
-    }
-}
-
-```
-
-- If a `match` arm's succesfully matches (destructures) a pattern, it introduces a new binding in that scope
-
-## Foreshadowing! Pattern Matching with logic 👻
-
-We'll see a more ergonomic form to handle a single case of interest and discard the rest
-
-```rust ignore
-let x = match pet {
-    Pet::Dog(dog_name) => format!("My true love is {}", dog_name),
-    _ => format!("I only care about dogs, sorry"),
-}
-```
-
 ## `for` loops
 
 - `for` is used for iteration

--- a/training-slides/src/control-flow.md
+++ b/training-slides/src/control-flow.md
@@ -2,18 +2,18 @@
 
 ## Control Flow primitives
 
--   `if` expressions
--   `loop` and `while` loops
--   `match` expressions
--   `for` loops
--   `break` and `continue`
--   `return` and `?`
+- `if` expressions
+- `loop` and `while` loops
+- `match` expressions
+- `for` loops
+- `break` and `continue`
+- `return` and `?`
 
 ## Using `if` as a statement
 
--   Tests if a boolean expression is `true` 
--   Parentheses around the conditional are not necessary
--   Blocks need brackets, no shorthand
+- Tests if a boolean expression is `true`
+- Parentheses around the conditional are not necessary
+- Blocks need brackets, no shorthand
 
 ```rust []
 fn main() {
@@ -29,8 +29,8 @@ fn main() {
 
 ## Using `if` as an expression
 
--   Every block is an expression
--   Note the final `;` to terminate the `let` statement.
+- Every block is an expression
+- Note the final `;` to terminate the `let` statement.
 
 ```rust []
 fn main() {
@@ -74,7 +74,7 @@ fn main() {
 }
 ```
 
-## Looping with `loop`
+## Looping with `loop` 2
 
 `loop` blocks are also expressions...
 
@@ -92,8 +92,8 @@ fn main() {
 
 ## `while`
 
--   `while` is used for conditional loops.
--   Loops while the boolean expression is `true`
+- `while` is used for conditional loops.
+- Loops while the boolean expression is `true`
 
 ```rust []
 fn main() {
@@ -107,10 +107,10 @@ fn main() {
 
 ## Control Flow with `match`
 
--   The `match` keyword does *pattern matching*
--   You can use it a bit like an `if/else if/else` expression
--   The first arm to match, wins
--   `_` means *match anything*
+- The `match` keyword does *pattern matching*
+- You can use it a bit like an `if/else if/else` expression
+- The first arm to match, wins
+- `_` means *match anything*
 
 ```rust []
     fn main() {
@@ -122,10 +122,43 @@ fn main() {
     }
 ```
 
+## Foreshadowing! Pattern Matching with bindings 👻
+
+`match` is extremely powerful, we'll come back to it.
+
+```rust ignore
+enum Pets {
+    Dog(String),
+    Cat(String),
+}
+
+fn test_pet(pet: Pets) {
+    match pet {
+        Pets::Cat(cat_name) => println!("Cat name is {}", cat_name),
+        Pets::Dog(dog_name) => println!("Dog name is {}", dog_name), 
+        //          👆 New binding `dog_name` now exists for this match arm!
+    }
+}
+
+```
+
+- If a `match` arm's succesfully matches (destructures) a pattern, it introduces a new binding in that scope
+
+## Foreshadowing! Pattern Matching with logic 👻
+
+We'll see a more ergonomic form to handle a single case of interest and discard the rest
+
+```rust ignore
+let x = match pet {
+    Pet::Dog(dog_name) => format!("My true love is {}", dog_name),
+    _ => format!("I only care about dogs, sorry"),
+}
+```
+
 ## `for` loops
 
--   `for` is used for iteration
--   Here `0..10` creates a `Range`, which you can iterate
+- `for` is used for iteration
+- Here `0..10` creates a `Range`, which you can iterate
 
 ```rust []
 fn main() {
@@ -135,7 +168,7 @@ fn main() {
 }
 ```
 
-## `for` loops
+## `for` loops 2
 
 Lots of things are *iterable*
 
@@ -149,8 +182,8 @@ fn main() {
 
 ## `for` under the hood
 
--    What Rust actually does is more like...
--    (More on this in the section on *Iterators*)
+- What Rust actually does is more like...
+- (More on this in the section on *Iterators*)
 
 ```rust []
 fn main() {
@@ -200,8 +233,8 @@ fn main() {
 
 ## `return`
 
--   `return` can be used for early returns
--   The result of the last expression of a function is always returned
+- `return` can be used for early returns
+- The result of the last expression of a function is always returned
 
 ```rust []
 fn get_number(x: bool) -> i32 {

--- a/training-slides/src/debugging-rust.md
+++ b/training-slides/src/debugging-rust.md
@@ -2,14 +2,14 @@
 
 ## tl;dr
 
-*VSCode + CodeLLDB*
+Best option: *VSCode + CodeLLDB*
 
 The best debugging experience on Windows, Linux, and macOS
 
 ## Honorable Mentions
 
-*   IntelliJ Rust
-*   `rr` / Pernosco for time-traveling and postmortem debugging
+* IntelliJ Rust
+* `rr` / Pernosco for time-traveling and postmortem debugging
 
 ## How Debuggers Work
 
@@ -17,40 +17,40 @@ Debuggers use special metadata embedded into executable to correctly match bits 
 
 Kinda like Source Maps for JavaScript.
 
-## How Debuggers Work
+## How Debuggers Work 2
 
 Two things have to happen for a debugger to work and provide decent developer experience:
 
-*   The compiler has to emit debug info.
-*   The debugger has to be modified / extended to _understand_ this information.
+* The compiler has to emit debug info.
+* The debugger has to be modified / extended to *understand* this information.
 
-## How Debuggers Work
+## How Debuggers Work 3
 
 Two things have to happen for a debugger to work and provide decent developer experience:
 
-*   *The compiler has to emit debug info.*
-*   The debugger has to be modified / extended to _understand_ this information.
+* *The compiler has to emit debug info.*
+* The debugger has to be modified / extended to *understand* this information.
 
 ## Compiler
 
 `rustc` uses `llvm` which emits debug info in DWARF or PDB format.
 
-*   [PDB](http://blog.llvm.org/2017/08/llvm-on-windows-now-supports-pdb-debug.html) is produced by `windows-msvc` toolchains (like `x86_64-pc-windows-msvc`)
-*   [DWARF](https://dwarfstd.org) is used by all other toolchains, including GNU toolchains on Windows (like `x86_64-pc-windows-gnu`)
+* [PDB](http://blog.llvm.org/2017/08/llvm-on-windows-now-supports-pdb-debug.html) is produced by `windows-msvc` toolchains (like `x86_64-pc-windows-msvc`)
+* [DWARF](https://dwarfstd.org) is used by all other toolchains, including GNU toolchains on Windows (like `x86_64-pc-windows-gnu`)
 
 ## DWARF
 
-*   Open standard.
-*   Very C/C++ specific.
-*   Has custom field types for other languages to use.
-*   Rust tries to reuse existing C/C++ fields where possible, so many debuggers work out of the box.
-*   A companion to *ELF*...
+* Open standard.
+* Very C/C++ specific.
+* Has custom field types for other languages to use.
+* Rust tries to reuse existing C/C++ fields where possible, so many debuggers work out of the box.
+* A companion to *ELF*...
 
 ## Extending DWARF
 
 DWARF standard is growing organically over time and largely implementation driven.
 
-## Extending DWARF
+## Extending DWARF 2
 
 1. Come up with a new name for Rust-specific DWARF field.
 2. Change the compiler to emit new debug info and use this field.
@@ -61,49 +61,49 @@ Standardizing takes almost no time due to how few people in the world actually w
 
 ## PDB
 
-*   Proprietary format with no documentation.
-*   Like DWARF is very C/C++ centric.
-*   Harder to extend.
-*   Rust tries to reuse C/C++ fields as much as possible, so debugging is still reasonable.
+* Proprietary format with no documentation.
+* Like DWARF is very C/C++ centric.
+* Harder to extend.
+* Rust tries to reuse C/C++ fields as much as possible, so debugging is still reasonable.
 
 ---
 
 You may have a better experience debugging Rust on macOS or Linux than on Windows, because of PDB.
 
-## How Debuggers Work
+## How Debuggers Work 4
 
 Two things have to happen for a debugger to work and provide decent developer experience:
 
-*   The compiler has to emit debug info.
-*   *The debugger has to be modified / extended to understand this information.*
+* The compiler has to emit debug info.
+* *The debugger has to be modified / extended to understand this information.*
 
 ## Debuggers
 
-*   [GDB](https://sourceware.org/gdb/onlinedocs/gdb/Rust.html)
-*   [LLDB](https://lldb.llvm.org) 
+* [GDB](https://sourceware.org/gdb/onlinedocs/gdb/Rust.html)
+* [LLDB](https://lldb.llvm.org)
 
 IDEs and editors rely on these two to provide GUI debugging
 
 ## GDB
 
-*   Supports a lot of languages.
-*   Adopts Rust-specific features quickly.
-*   Harder to contribute in general.
+* Supports a lot of languages.
+* Adopts Rust-specific features quickly.
+* Harder to contribute in general.
 
 ## LLDB
 
-*   *Default choice for Rust.*
-*   Part of LLVM that Rust uses for compilation.
-*   Used to support many languages, but the team decided to focus on C, C++, and Objective C only.
-*   Has extension API for supporting other languages, which is not enough for Rust.
+* *Default choice for Rust.*
+* Part of LLVM that Rust uses for compilation.
+* Used to support many languages, but the team decided to focus on C, C++, and Objective C only.
+* Has extension API for supporting other languages, which is not enough for Rust.
 
-## LLDB
+## LLDB 2
 
 Rust project maintains a fork of LLDB with extended support for the language.
 
-*   Part of overall LLVM fork.
-*   Constantly updated and well-maintained.
-*   Non-Rust-specific bug fixes get upstreamed to main LLVM repository
+* Part of overall LLVM fork.
+* Constantly updated and well-maintained.
+* Non-Rust-specific bug fixes get upstreamed to main LLVM repository
 
 ## Wrappers
 
@@ -121,67 +121,67 @@ Prompts you to install one when you open a Rust project.
 
 ## VSCode Extensions
 
-*   [Microsoft C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
-*   [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug).
-*   [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
+* [Microsoft C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+* [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug).
+* [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
 
-## CodeLLDB.
+## CodeLLDB
 
-*   LLDB-only.
-*   *Maintains it's own fork of Rust's LLDB with even more Rust enhancements!*
-*   Downloads it on first installation.
-*   Seamless debugging experience.
+* LLDB-only.
+* *Maintains it's own fork of Rust's LLDB with even more Rust enhancements!*
+* Downloads it on first installation.
+* Seamless debugging experience.
 
 ---
 
-Both Microsoft C/C++ and Native Debug support GDB _and_ LLDB.
+Both Microsoft C/C++ and Native Debug support GDB *and* LLDB.
 
 Microsoft's extension offers better support for displaying PDB information on Windows.
 
 ## IntelliJ-Rust
 
-*   A plugin for IDEA and CLion
-*   Produced by JetBrain.
-*   Like CodeLLDB also maintains it's own fork of Rust's LLDB for better DX.
-*   Requires a JB license.
+* A plugin for IDEA and CLion
+* Produced by JetBrain.
+* Like CodeLLDB also maintains it's own fork of Rust's LLDB for better DX.
+* Requires a JB license.
 
 ## What to use?
 
-*   *VSCode + CodeLLDB offer the best debugging experience across all platforms.*
-*   [Microsoft recommends CodeLLDB even for Windows use.](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup)
-*   IntelliJ-Rust is great if that's your IDE of choice.
-*   Native Debug and Microsoft C/C++ extensions can work for you on platforms where only GDB is available.
+* *VSCode + CodeLLDB offer the best debugging experience across all platforms.*
+* [Microsoft recommends CodeLLDB even for Windows use.](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup)
+* IntelliJ-Rust is great if that's your IDE of choice.
+* Native Debug and Microsoft C/C++ extensions can work for you on platforms where only GDB is available.
 
 ## `rr`
 
-*   [A Linux-only terminal-based time-traveling debugger.](https://rr-project.org) 
-*   Uses GDB under the hood, supports Rust.
-*   [Pernosco](https://pernos.co) - GUI debugging tool on top of `rr` on top of `gdb` - offers Rust support, too.
-*   May help you in very difficult situations.
+* [A Linux-only terminal-based time-traveling debugger.](https://rr-project.org)
+* Uses GDB under the hood, supports Rust.
+* [Pernosco](https://pernos.co) - GUI debugging tool on top of `rr` on top of `gdb` - offers Rust support, too.
+* May help you in very difficult situations.
 
 ## Things may not work well
 
-*   PDB may result in subpar debugging experience.
-    *  If possible try debugging your code on OSes other than Windows 
-    *  Or try using GNU-based toolchain on Windows.
-*   Watch expressions are limited. 
-    *  Can't use `match` or `if` expressions
-    *  Some method calls may not produce results.
-*   Some values can't be shown: function preferences, closures.
-*   Breakpoints may sometimes not work in closures and in async code.
-*   Trait objects and trait methods may be difficult for debugger to resolve.
+* PDB may result in subpar debugging experience.
+  * If possible try debugging your code on OSes other than Windows
+  * Or try using GNU-based toolchain on Windows.
+* Watch expressions are limited.
+  * Can't use `match` or `if` expressions
+  * Some method calls may not produce results.
+* Some values can't be shown: function preferences, closures.
+* Breakpoints may sometimes not work in closures and in async code.
+* Trait objects and trait methods may be difficult for debugger to resolve.
 
 ## When debugger fails you
 
-*   Try to isolate the code in question into smaller functions.
-*   Add debug logging / tracing.
-*   Tests.
+* Try to isolate the code in question into smaller functions.
+* Add debug logging / tracing.
+* Tests.
 
 ## Future
 
-*   *New [Rust Debugging](https://blog.rust-lang.org/inside-rust/2022/02/22/compiler-team-ambitions-2022.html#debugging-aspirations-) Working Group:*
-    *  Unites people from Rust, GDB, and `rr`
-    *  people from LLVM, CodeLLDB, Rust-Analyzer, and IntelliJ Rust expressed interest in helping out.🎉
-*   Plans:
-    *  LLVM team is open to merge Rust-specific features into LLDB directly, may not need a Rust fork, or CodeLLDB / IntelliJ forks.
-    *  Further expand DWARF to cover tricky Rust features like trait object method references.
+* *New [Rust Debugging](https://blog.rust-lang.org/inside-rust/2022/02/22/compiler-team-ambitions-2022.html#debugging-aspirations-) Working Group:*
+  * Unites people from Rust, GDB, and `rr`
+  * people from LLVM, CodeLLDB, Rust-Analyzer, and IntelliJ Rust expressed interest in helping out.🎉
+* Plans:
+  * LLVM team is open to merge Rust-specific features into LLDB directly, may not need a Rust fork, or CodeLLDB / IntelliJ forks.
+  * Further expand DWARF to cover tricky Rust features like trait object method references.

--- a/training-slides/src/dependency-management.md
+++ b/training-slides/src/dependency-management.md
@@ -16,28 +16,28 @@ clap = "2.2" # would also choose 2.3
 
 * contains a list of all project dependencies, de-facto versions and hashes of downloaded dependencies
 * when a version is *yanked* from `Crates.io` but you have the correct hash for it in a lock file Cargo will still let you download it and use it
-    * still gives you warning about that version being problematic
+  * still gives you warning about that version being problematic
 * should be committed to your repository for applications
 
 ## Dependency resolution
 
 * uses "Zero-aware" SemVer for versioning
-    * `1.3.5` is compatible with versions `>= 1.3.5` and `< 2.0.0`
-    * `0.3.5` is compatible with versions `>= 0.3.5` and `< 0.4.0`
-    * `0.0.3` only allows `0.0.3`
+  * `1.3.5` is compatible with versions `>= 1.3.5` and `< 2.0.0`
+  * `0.3.5` is compatible with versions `>= 0.3.5` and `< 0.4.0`
+  * `0.0.3` only allows `0.0.3`
 * allows version-incompatible transitive dependencies
-    * except C/C++ dependencies
+  * except C/C++ dependencies
 * combines dependencies with compatible requirements as much as possible
 * allows path, git, and custom registry dependencies
 
 ## How a dependency version is selected
 
 * for every requirement Cargo selects acceptable version intervals
-    * `[1.1.0; 1.6.0)`, `[1.3.5, 2.0.0)`, `[2.0.0; 3.0.0)`
+  * `[1.1.0; 1.6.0)`, `[1.3.5, 2.0.0)`, `[2.0.0; 3.0.0)`
 * Cargo checks for interval intersections to reduce the number of unique intervals
-    * `[1.3.5; 1.6.0)`, `[2.0.0; 3.0.0)`
+  * `[1.3.5; 1.6.0)`, `[2.0.0; 3.0.0)`
 * for every unique interval it selects the most recent available version
-    * `=1.5.18`, `=2.7.11`
+  * `=1.5.18`, `=2.7.11`
 * selected versions and corresponding package hashes are written into `Cargo.lock`
 
 ## Dependency resolution: Example
@@ -62,19 +62,19 @@ clap = "2.2" # would also choose 2.3
 Notes:
 
 * private registries
-    * hosted: **Shipyard**, JFrog, CloudSmith
-    * self-hosted: **Kellnr**
-    * open-source: [Ktra](https://github.com/moriturus/ktra) - pronounced `['KO-to-ra]`, [Meuse](https://github.com/mcorbin/meuse) - `[Møs]`
+  * hosted: **Shipyard**, JFrog, CloudSmith
+  * self-hosted: **Kellnr**
+  * open-source: [Ktra](https://github.com/moriturus/ktra) - pronounced `['KO-to-ra]`, [Meuse](https://github.com/mcorbin/meuse) - `[Møs]`
 
-*Shipyard and Kellnr will also generate API docs for you*
+Notice! *Shipyard and Kellnr will also generate API docs for you*
 
 ## Crates.io
 
 * default package registry
-    * 100k crates and counting
-    * **every Rust Beta release is tested against all of them every week**
+  * 100k crates and counting
+  * **every Rust Beta release is tested against all of them every week**
 * packages aren't deleted, but *yanked*
-    * if you have a correct hash for a yanked version in your `Cargo.lock` your build won't break (you still get a warning)
+  * if you have a correct hash for a yanked version in your `Cargo.lock` your build won't break (you still get a warning)
 
 ## Docs.rs
 
@@ -86,30 +86,31 @@ Notes:
 ## Other kinds of dependencies
 
 * git dependencies
-    * both `git+https` and `git+ssh` are allowed
-    * can specify branch, tag, commit hash
-    * when downloaded by Cargo exact commit hash used is written into `Cargo.lock`
+  * both `git+https` and `git+ssh` are allowed
+  * can specify branch, tag, commit hash
+  * when downloaded by Cargo exact commit hash used is written into `Cargo.lock`
 * path dependencies
-    * both relative and absolute paths are allowed
-    * common in workspaces
+  * both relative and absolute paths are allowed
+  * common in workspaces
 
 ## C Libraries as dependencies
 
 * Rust can call functions from C libraries using `unsafe` code
-    * integrate with operating system APIs, frameworks, SDKs, etc.
-    * talk to custom hardware
-    * reuse existing code (SQLite, OpenSSL, libgit2, etc.)
+  * integrate with operating system APIs, frameworks, SDKs, etc.
+  * talk to custom hardware
+  * reuse existing code (SQLite, OpenSSL, libgit2, etc.)
 * building a crate that relies on C libraries often requires customization
-    * done using `build.rs` file
+  * done using `build.rs` file
 
 ## `build.rs` file
 
 * compiled and executed before the rest of the package
 * can manipulate files, execute external programs, etc.
-    * download / install custom SDKs
-    * call `cc`, `cmake`, etc. to build C++ dependencies
-    * execute `bindgen` to generate Rust bindings to C libraries
+  * download / install custom SDKs
+  * call `cc`, `cmake`, etc. to build C++ dependencies
+  * execute `bindgen` to generate Rust bindings to C libraries
 * output can be used to set Cargo options dynamically
+
     ```rust ignore
     println!("cargo:rustc-link-lib=gizmo");
     println!("cargo:rustc-link-search=native={}/gizmo/", library_path);
@@ -118,13 +119,13 @@ Notes:
 ## `-sys` crates
 
 * often Rust libraries that integrate with C are split into a pair of crates:
-    * `library-name-sys`
-        * thin wrapper around C functions
-        * often all code is autogenerated by `bindgen`
-    *  `library-name`
-        * depends on `library-name-sys`
-        * exposes convenient and idiomatic Rust API to users
+  * `library-name-sys`
+    * thin wrapper around C functions
+    * often all code is autogenerated by `bindgen`
+  * `library-name`
+    * depends on `library-name-sys`
+    * exposes convenient and idiomatic Rust API to users
 * examples:
-    * `openssl` and `openssl-sys`
-    * `zstd` and `zstd-sys`
-    * `rusqlite` and `libsqlite3-sys`
+  * `openssl` and `openssl-sys`
+  * `zstd` and `zstd-sys`
+  * `rusqlite` and `libsqlite3-sys`

--- a/training-slides/src/deref-coercions.md
+++ b/training-slides/src/deref-coercions.md
@@ -22,10 +22,10 @@ Box doesn't have a field named "x"!
 
 Rust automatically dereferences in certain cases. Like everything else, it must be explicitly requested:
 
--   Through a call or field access using the `.` operator
--   By explicitly dereferencing through `*`
--   When borrowing through `&`
--   This sometimes leads to the ugly `&*`-Pattern
+- Through a call or field access using the `.` operator
+- By explicitly dereferencing through `*`
+- When borrowing through `&`
+- This sometimes leads to the ugly `&*`-Pattern
 
 ---
 
@@ -49,8 +49,8 @@ This call is introduced when dereferencing is requested.
 
 ## Important deref behaviours
 
--   String -&gt; &str
--   Vec<T> -&gt; &[T]
+- `String --> &str`
+- `Vec<T> --> &[T]`
 
 Functions that don't modify the lengths of a String or a Vector should accept a slice instead. The memory layout is chosen so that this is *cost free*.
 

--- a/training-slides/src/documentation.md
+++ b/training-slides/src/documentation.md
@@ -13,7 +13,7 @@ The standard library documentation is hosted at https://doc.rust-lang.org/std/.
 A local, offline version can be opened with:
 
 ```console
-$ rustup doc --std
+rustup doc --std
 ```
 
 ## Crate Documentation
@@ -89,7 +89,7 @@ The sidebar on the left offers quick navigate to other parts of the module.
 This command builds and opens the docs to your current project:
 
 ```sh
-$ cargo doc --open
+cargo doc --open
 ```
 
 ---
@@ -97,5 +97,5 @@ $ cargo doc --open
 Normally only `pub` items are documented. You can change this:
 
 ```sh
-$ cargo doc --document-private-items --open
+cargo doc --document-private-items --open
 ```

--- a/training-slides/src/drop-panic-abort.md
+++ b/training-slides/src/drop-panic-abort.md
@@ -8,7 +8,7 @@ What happens in detail when values drop?
 
 Rust generally guarantees drop order ([RFC1857](https://github.com/rust-lang/rfcs/issues/1857))
 
-## Drop-Order
+## Drop-Order 2
 
 - Values are dropped at the end of their scope
 - The order is *the reverse introduction order*
@@ -63,9 +63,9 @@ fn panicking_function() {
 
 In case of a panic, the following happens:
 
-* The current thread immediately halts
-* The stack is unwound
-* All affected values are dropped and their destructors run
+- The current thread immediately halts
+- The stack is unwound
+- All affected values are dropped and their destructors run
 
 ---
 
@@ -76,7 +76,7 @@ The affected thread dies.
 ## Catching Panics
 
 Panicking across FFI-boundaries is undefined behaviour.
-In these cases, panics _must_ be caught.
+In these cases, panics *must_ be caught.
 For cases like this, there are [std::panic::catch-unwind](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html) and [std::panic::resume-unwind](https://doc.rust-lang.org/std/panic/fn.resume_unwind.html).
 
 ## Hooks

--- a/training-slides/src/dynamic-dispatch.md
+++ b/training-slides/src/dynamic-dispatch.md
@@ -65,8 +65,8 @@ Trait objects are a pair of pointers to a virtual function table and the data.
 
 - Object-safe traits are *not* allowed to require `Self: Sized`
 - All methods are object-safe
-    * They have no type parameters
-    * They don't use `Self`
+  - They have no type parameters
+  - They don't use `Self`
 
 ## Trait Objects and Closures
 

--- a/training-slides/src/error-handling.md
+++ b/training-slides/src/error-handling.md
@@ -48,7 +48,7 @@ enum Error { BadThing, OtherThing }
 
 If you use `?` to return the error early, some extra conversion happens:
 
-```rust [1-13|1|7|2] 
+```rust [1-13|1|7|2]
 fn main() -> Result<(), String> {
     let num = some_function(true)?;
     println!("num = {}", num);

--- a/training-slides/src/ffi.md
+++ b/training-slides/src/ffi.md
@@ -47,7 +47,7 @@ fn hello(param1: i32, param2: f64) -> SomeStruct { todo!() }
 
 Your Rust code might want to interact with shared/static libraries.
 
-Or _be_ one.
+Or *be* one.
 
 ## Efficient bindings
 
@@ -59,36 +59,36 @@ We have this amazing Rust library, we want to use in our existing C project.
 
 ```rust []
 struct MagicAdder {
-	amount: u32
+    amount: u32
 }
 
 impl MagicAdder {
-	fn new(amount: u32) -> MagicAdder {
-		MagicAdder {
-			amount
-		}
-	}
+    fn new(amount: u32) -> MagicAdder {
+        MagicAdder {
+            amount
+        }
+    }
 
-	fn process_value(&self, value: u32) -> u32 {
-		self.amount + value
-	}
+fn process_value(&self, value: u32) -> u32 {
+    self.amount + value
+    }
 }
 ```
 
 ## Things TODO
 
-- Tell C these functions exist
-- Tell Rust to use C-compatible types and functions
-- Link the external code as a library
-- Provide some C types that match the Rust types
-- Call our Rust functions
+* Tell C these functions exist
+* Tell Rust to use C-compatible types and functions
+* Link the external code as a library
+* Provide some C types that match the Rust types
+* Call our Rust functions
 
 ## C-flavoured Rust Code
 
 ```rust []
 #[repr(C)]
 struct MagicAdder {
-	amount: u32
+ amount: u32
 }
 
 impl MagicAdder {
@@ -98,16 +98,16 @@ impl MagicAdder {
 
 #[no_mangle]
 extern "C" fn magicadder_new(amount: u32) -> MagicAdder {
-	MagicAdder::new(amount)
+ MagicAdder::new(amount)
 }
 
 #[no_mangle]
 extern "C" fn magicadder_process_value(adder: *const MagicAdder, value: u32) -> u32 {
-	if let Some(ma) = unsafe { adder.as_ref() } {
-		ma.process_value(value)
-	} else {
-		0
-	}
+ if let Some(ma) = unsafe { adder.as_ref() } {
+  ma.process_value(value)
+ } else {
+  0
+ }
 }
 ```
 
@@ -120,7 +120,7 @@ The `.as_ref()` method on pointers *requires* that the pointer either be null, o
 ```c []
 /// Designed to have the exact same shape as the Rust version
 typedef struct magic_adder_t {
-	uint32_t amount;
+ uint32_t amount;
 } magic_adder_t;
 
 /// Wraps MagicAdder::new
@@ -136,11 +136,10 @@ You can tell `rustc` to make:
 
 * binaries (bin)
 * libraries (lib)
-    - rlib
-    - dylib
-    - staticlib
-    - cdylib
-
+  * rlib
+  * dylib
+  * staticlib
+  * cdylib
 
 Note:
 
@@ -169,6 +168,7 @@ See ./examples/ffi_use_rust_in_c for a working example.
 We have this amazing C library, we want to use as-is in our Rust project.
 
 `cool_library.h`:
+
 ```c []
 #include <stdint.h>
 
@@ -177,6 +177,7 @@ uint32_t cool_library_function(uint32_t x, uint32_t y);
 ```
 
 `cool_library.c`:
+
 ```c []
 #include <stdio.h>
 #include "hello.h"
@@ -188,12 +189,12 @@ uint32_t cool_library_function(uint32_t x, uint32_t y)
 }
 ```
 
-## Things TODO
+## Things TODO 2
 
-- Tell Rust these functions exist
-- Link the external code as a library
-- Call those with `unsafe { ... }`
-- Transmute data for C functions
+* Tell Rust these functions exist
+* Link the external code as a library
+* Call those with `unsafe { ... }`
+* Transmute data for C functions
 
 ## Naming things is hard
 
@@ -221,7 +222,6 @@ extern "C" {
     fn cool_library_function(x: c_uint, y: c_uint) -> c_uint;
 }
 ```
-
 
 Note:
 
@@ -262,12 +262,12 @@ fn main() {
 }
 ```
 
-## Some more specific details...
+## Some more specific details
 
 ## Cargo (build-system) support
 
 * Build native code via build-dependency crates:
-    - [cc](https://crates.io/crates/cc), [cmake](https://crates.io/crates/cmake), ...
+  * [cc](https://crates.io/crates/cc), [cmake](https://crates.io/crates/cmake), ...
 * `build.rs` can give linker extra arguments
 
 ## Opaque types
@@ -280,9 +280,9 @@ When not knowing (or caring) about internal layout, [opaque structs](https://doc
 pub struct FoobarContext { _priv: [i32; 0] }
 
 extern "C" {
-	fn foobar_init() -> *mut FoobarContext;
-	fn foobar_do(ctx: *mut FoobarContext, foo: i32);
-	fn foobar_destroy(ctx: *mut FoobarContext);
+ fn foobar_init() -> *mut FoobarContext;
+ fn foobar_do(ctx: *mut FoobarContext, foo: i32);
+ fn foobar_destroy(ctx: *mut FoobarContext);
 }
 
 /// Use this in your Rust code

--- a/training-slides/src/generics.md
+++ b/training-slides/src/generics.md
@@ -315,4 +315,3 @@ Things that don't have sizes known at compile time (but which may or may not imp
 
 * String Slices
 * Closures
-

--- a/training-slides/src/glossary.md
+++ b/training-slides/src/glossary.md
@@ -16,4 +16,3 @@ These are some of the terms we will be using throughout our training.
 |                                Quizzes                                | Mini-tests of the training material                                                           |
 |                             Ice Breakers                              | Brief warm-up activities to get the training started, usually short Questions                 |
 | [Training Material](https://github.com/ferrous-systems/rust-training) | These training materials                                                                      |
-

--- a/training-slides/src/good-design-practices.md
+++ b/training-slides/src/good-design-practices.md
@@ -10,6 +10,7 @@
 ```shell
 cargo new my_app
 ```
+
 ```text
 my_app/
 ├── src/
@@ -22,6 +23,7 @@ my_app/
 ```shell
 cargo new --lib my_library
 ```
+
 ```text
 my_library/
 ├── src/
@@ -54,8 +56,8 @@ mod tests {
 
 * mark your function with `#[test]`
 * use `assert!`, `assert_eq!`, `assert_ne!` for assertions
-    * `assert_eq!`, `assert_ne!` will show you the difference between left and right arguments
-    * all assertions take an optional custom error message argument
+  * `assert_eq!`, `assert_ne!` will show you the difference between left and right arguments
+  * all assertions take an optional custom error message argument
 * first failed assertion in a test function will stop the current test, other tests will still run
 * `cargo test` will run all tests
 
@@ -71,10 +73,11 @@ fn main() {
 ```
 
 Errors:
+
 * "binary operation `==` cannot be applied to type `Point`"
-    * can't compare two Points
+  * can't compare two Points
 * "`Point` doesn't implement `Debug`"
-    * can't print out a Point in error messages
+  * can't print out a Point in error messages
 
 ## Derives - adding behavior to your types
 
@@ -117,6 +120,7 @@ fn main() {
 ## `PartialEq` and `Eq`
 
 `Eq` means strict mathematical equality:
+
 1. `a == a` should always be true
 2. `a == b` means `b == a`
 3. `a == b` and `b == c` means `a == c`
@@ -129,24 +133,24 @@ IEEE 754 floating point numbers (`f32` and `f64`) break the first rule (`NaN == 
 * Generally, everything is `Ord`, except `f32` and `f64`.
 * Characters are compared by their code point numerical values
 * Arrays and slices are compared element by element. Length acts as a tiebreaker.
-    * `"aaa" < "b"`, but `"aaa" > "a"`
-    * elements themselves have to be `PartialOrd` or `Ord`
+  * `"aaa" < "b"`, but `"aaa" > "a"`
+  * elements themselves have to be `PartialOrd` or `Ord`
 
 ## How derives work?
 
 * `Debug`, `PartialEq`, `Eq`, etc. are simultaneously names of "Traits" and names of "derive macros".
 * If a trait has a corresponding derive macro it can be "derived":
-    * Rust will generate a default implementation.
+  * Rust will generate a default implementation.
 * Not all traits have a corresponding derive macros
-    * these traits have to be implemented manually.
+  * these traits have to be implemented manually.
 
 ## `Debug` and `Display`
 
 * a pair of traits.
 * `Debug` is for debug printing
-    * can be derived
+  * can be derived
 * `Display` is for user-facing printing
-    * cannot be derived, and must be implemented manually
+  * cannot be derived, and must be implemented manually
 
 ```rust ignore
 println!("{:?}", value); // uses `Debug`
@@ -171,9 +175,9 @@ Traits can depend on each other.
 
 * `Hash` - a type can be used as a key for `HashMap`
 * `Default` - a type gets a `default()` method to produce a default value
-    * `0` is used for numbers, `""` for strings
-    * collections starts as empty
-    * `Option` fields will be `None`
+  * `0` is used for numbers, `""` for strings
+  * collections starts as empty
+  * `Option` fields will be `None`
 * `Clone` adds a `clone()` method to produce a deep copy of a value
 
 `derive` lists can get be pretty long.
@@ -183,19 +187,21 @@ Traits can depend on each other.
 * `///` marks doc comments
 * Markdown
 * Rust fragments in doc comments produce documentation tests
-    * Use it to test you examples.
+  * Use it to test you examples.
 * Example from a standard library:
-    * [`Vec::len()` docs page](https://doc.rust-lang.org/1.69.0/std/vec/struct.Vec.html#method.len)
-    * [`Vec::len()` docs source code](https://doc.rust-lang.org/1.69.0/src/alloc/vec/mod.rs.html#2050)
+  * [`Vec::len()` docs page](https://doc.rust-lang.org/1.69.0/std/vec/struct.Vec.html#method.len)
+  * [`Vec::len()` docs source code](https://doc.rust-lang.org/1.69.0/src/alloc/vec/mod.rs.html#2050)
 
 ## Formatting and Linting
 
 `rustfmt` is a default Rust formatter
+
 ```shell
 cargo fmt
 ```
 
 `Clippy` is a linter for Rust code
+
 ```shell
 cargo clippy
 ```

--- a/training-slides/src/heap.md
+++ b/training-slides/src/heap.md
@@ -21,7 +21,7 @@ Note:
 * The variable `y` is a 4-byte value, and also lives on the stack.
 * The variable `z` is a 3x4-byte value on 32-bit platforms, and a 3x8-byte value on 64-bit platforms. The `String` itself is a struct, and the bytes contained within the struct live on the heap.
 
-## Let's see some addresses...
+## Let's see some addresses
 
 ```rust []
 struct Square {
@@ -165,7 +165,7 @@ because each will always have at least one owner (the other).
 ## Thread-safety
 
 * `Rc` cannot be sent into a thread (or through any API that requires the type to be `Send`).
-    * If in doubt, try it! Rust will save you from yourself.
+  * If in doubt, try it! Rust will save you from yourself.
 * The trade-off is that `Rc` is really fast!
 * There is an *Atomic Reference Counted* type, `Arc` if you need it.
 

--- a/training-slides/src/imports-and-modules.md
+++ b/training-slides/src/imports-and-modules.md
@@ -5,7 +5,7 @@
 * A namespace is simply a way to distinguish two things that have the same name.
 * It provides a *scope* to the identifiers within it.
 
-## Rust supports namespacing in two ways:
+## Rust supports namespacing in 2 ways
 
 1. Crates for re-usable software libraries
 2. Modules for breaking up your crates
@@ -136,7 +136,7 @@ use std::collections::VecDeque;
 use std::io::prelude::*;
 ```
 
-## Standard Library
+## Standard Library 2
 
 There's also a more compact syntax for imports.
 

--- a/training-slides/src/installation.md
+++ b/training-slides/src/installation.md
@@ -66,18 +66,17 @@ Hello, world!
 
 ## A Little Look Around
 
--   What is in Cargo.toml?
--   What is in Cargo.lock?
+- What is in Cargo.toml?
+- What is in Cargo.lock?
 
 For details, check the [Cargo Manifest docs](http://doc.crates.io/manifest.html).
 
 ## IDEs
 
--   rust-analyzer: <https://rust-analyzer.github.io>
-    - Implements the *Language Server Protocol*
-    - Emacs, vim, Sublime, VS Code, Kate, etc...
-    - Now the official VS Code extension for Rust!
-    - Open Source, funded by donations
--   IntelliJ Rust plugin for their IDEs (CLion, Idea, etc.):
+- rust-analyzer: <https://rust-analyzer.github.io>
+  - Implements the *Language Server Protocol*
+  - Emacs, vim, Sublime, VS Code, Kate, etc...
+  - Now the official VS Code extension for Rust!
+  - Open Source, funded by donations
+- IntelliJ Rust plugin for their IDEs (CLion, Idea, etc.):
     <https://www.jetbrains.com/rust/>
-

--- a/training-slides/src/io.md
+++ b/training-slides/src/io.md
@@ -1,6 +1,6 @@
 # Rust I/O Traits
 
-## There are two kinds of computer:
+## There are two kinds of computers:
 
 * Windows NT based
 * POSIX based (macOS, Linux, QNX, etc)

--- a/training-slides/src/iterators.md
+++ b/training-slides/src/iterators.md
@@ -4,7 +4,6 @@
 
 > iterate (verb): to repeat a process, especially as part of a computer program ([Cambridge English Dictionary](https://dictionary.cambridge.org/dictionary/english/iterate?q=Iterate))
 
-
 To *iterate* in Rust is to produce a sequence of items, one at a time.
 
 ## How do you Iterate?
@@ -49,7 +48,7 @@ fn main() {
 }
 ```
 
-## Basic usage
+## Basic usage 2
 
 Same thing, but with `while let`.
 
@@ -63,7 +62,7 @@ fn main() {
 }
 ```
 
-## Basic usage
+## Basic usage 3
 
 Same thing, but with `for`
 
@@ -77,7 +76,7 @@ fn main() {
 }
 ```
 
-## Basic usage
+## Basic usage 4
 
 Same thing, but we let `for` call `.into_iter()` for us.
 
@@ -120,7 +119,7 @@ classDiagram
     }
 ```
 
-## Three kinds of Iterator
+## Three kinds of Iterator 2
 
 * Borrowed (`data.iter()`)
 * Mutably Borrowed (`data.iter_mut()`)
@@ -140,7 +139,7 @@ fn main() {
 }
 ```
 
-## But how did that for-loop work?
+## But how did that for-loop work? 2
 
 The `&` is load-bearing...
 
@@ -177,7 +176,7 @@ Especially as `Range<T> where T: Copy` is not itself `Copy`.
 * Rust has some `traits` which describe how iterators work.
 * We'll talk more about traits later!
 
-# You can still enjoy it without knowing how it works
+## You can still enjoy it without knowing how it works
 
 ## Useful Iterator methods (1)
 

--- a/training-slides/src/lifetimes.md
+++ b/training-slides/src/lifetimes.md
@@ -4,9 +4,9 @@
 
 * Every piece of memory in Rust program has exactly one owner at the time
 * Ownership changes ("moves")
-    * `fn takes_ownership(data: Data)`
-    * `fn producer() -> Data`
-    * `let people = [paul, john, emma];`
+  * `fn takes_ownership(data: Data)`
+  * `fn producer() -> Data`
+  * `let people = [paul, john, emma];`
 
 ## Producing owned data
 
@@ -37,7 +37,7 @@ fn producer() -> &str {
 }
 ```
 
-## Local Data
+## Local Data 2
 
 No, we can't return a reference to local data...
 
@@ -77,7 +77,7 @@ How big is a `&'static str`? Do you think the length lives with the string data,
 * Rust never assumes `'static` for function returns or fields in types
 * `&'static T` means this reference to `T` will never become invalid
 * `T: 'static` means that "if type `T` has any references inside they should be `'static`"
-    * `T` may have no references inside at all!
+  * `T` may have no references inside at all!
 * string literals are always `&'static str`
 
 ---
@@ -126,9 +126,9 @@ fn takes_many_and_returns<'a>(s1: &str, s2: &'a str) -> &'a str {
 
 * "Lifetime annotation"
 * often called "lifetime" for short, but that's a very bad term
-    * every reference has a lifetime
-    * annotation doesn't name a lifetime of a reference, but used to tie lifetimes of several references together
-    * builds *"can't outlive"* and *"should stay valid for as long as"* relations
+  * every reference has a lifetime
+  * annotation doesn't name a lifetime of a reference, but used to tie lifetimes of several references together
+  * builds *"can't outlive"* and *"should stay valid for as long as"* relations
 * arbitrary names: `'a`, `'b`, `'c`, `'whatever`
 
 ## Lifetime annotations in action
@@ -230,7 +230,7 @@ fn pick_one(s1: &'? str, s2: &'? str) -> &'? str {
 }
 ```
 
-## What if multiple parameters can be sources?
+## What if multiple parameters can be sources? 2
 
 ```rust ignore
 fn pick_one<'a>(s1: &'a str, s2: &'a str) -> &'a str {
@@ -249,7 +249,7 @@ Note:
 
 This function body does not *force* the two inputs to live for the same amount of time. Variables live for as long as they live and we can't change that here. This just says "I'm going to use the same label for the lifetimes these two references have, so pick whichever is the shorter".
 
-## What if multiple parameters can be sources?
+## What if multiple parameters can be sources? 3
 
 ```rust []
 fn pick_one<'a>(s1: &'a str, s2: &'a str) -> &'a str {
@@ -290,6 +290,7 @@ struct Configuration<'a> {
     database_url: &'a str;
 }
 ```
+
 <p>&nbsp;<!-- spacer for "run" button --></p>
 
 An instance of `Configuration` *can't outlive* a string<br> that it refers to via `database_url`.
@@ -302,8 +303,8 @@ The string *can't be dropped<br> while* an instance of `Configuration` *still* r
 
 * Lifetime annotations act like generics from type system PoV.
 * Can be used to to add bounds to types: `where T: Debug + 'a`
-    * Type `T` has to be printable with `:?`.
-    * If `T` has references inside, they *have to stay valid for as long as* `'a` tag requires.
+  * Type `T` has to be printable with `:?`.
+  * If `T` has references inside, they *have to stay valid for as long as* `'a` tag requires.
 * Can be used to match lifetime generics in `struct` or `enum` with the annotations used in function signatures and in turn with exact lifetimes of references.
 
 ## Complex example
@@ -330,6 +331,6 @@ Returned value will not be allowed to outlive any reference in `peers` list
 ## Lifetime annotations in practice
 
 * Like generics, annotations make function signatures verbose and difficult to read
-    * they often can be glossed over when reading code
+  * they often can be glossed over when reading code
 * `T: 'static` means "Owned data or static references", owned data can be very short-lived
 * Using owned data in your types helps avoid borrow checker difficulties

--- a/training-slides/src/macros.md
+++ b/training-slides/src/macros.md
@@ -15,6 +15,8 @@ Macros can be used to things such as:
 
 # Declarative Macros
 
+Compile time copy/pasting 👿
+
 ## Declarative Macros
 
 * Defined using `macro_rules!`

--- a/training-slides/src/methods-traits.md
+++ b/training-slides/src/methods-traits.md
@@ -41,7 +41,7 @@ For motivation for something that takes `self`, imagine an embedded device with 
 * `self` means `self: Self`
 * `Self` means whatever type this `impl` block is for
 
-## Method Receivers
+## Method Receivers 2
 
 * Other, fancier, *method receivers* [are available](https://doc.rust-lang.org/reference/items/associated-items.html)!
 
@@ -191,7 +191,7 @@ You can only *use* the trait methods provided by a *Trait* on a *Type* if:
 * The trait is in scope
 * (e.g. you add `use Trait;` in that module)
 
-## Traits
+## Traits 2
 
 * The standard library provides lots of traits, such as:
   * [std::cmp::PartialEq] and [std::cmp::Eq]

--- a/training-slides/src/overview.md
+++ b/training-slides/src/overview.md
@@ -21,33 +21,33 @@ Rust is an empathic systems programming language that is determined to not let y
 
 ## A Little Bit of History
 
--   Rust began around 2008
--   An experimental project by Graydon Hoare
--   Adopted by Mozilla
--   Presented to the general public as version 0.4 in 2012
--   Looked a bit Go-like back then
+- Rust began around 2008
+- An experimental project by Graydon Hoare
+- Adopted by Mozilla
+- Presented to the general public as version 0.4 in 2012
+- Looked a bit Go-like back then
 
 ## Focus
 
--   Rust has lost many features from 2012 to 2014
-    -   Garbage collector
-    -   evented runtime
-    -   complex error handling
--   Orientation towards a usable systems programming language
+- Rust has lost many features from 2012 to 2014
+  - Garbage collector
+  - evented runtime
+  - complex error handling
+- Orientation towards a usable systems programming language
 
 ## Development
 
--   Always together with a larger project (e.g. Servo)
--   Early adoption of regular releases, deprecations and an RFC process
+- Always together with a larger project (e.g. Servo)
+- Early adoption of regular releases, deprecations and an RFC process
 
 ## Release Method
 
--   Nightly releases
--   experimental features are only present on nighly releases
--   Every 6 weeks, the current nightly is promoted to beta
--   After 6 weeks of testing, beta becomes stable
--   Guaranteed backwards-compatibility
--   Makes small iterations easier
+- Nightly releases
+- experimental features are only present on nighly releases
+- Every 6 weeks, the current nightly is promoted to beta
+- After 6 weeks of testing, beta becomes stable
+- Guaranteed backwards-compatibility
+- Makes small iterations easier
 
 Note:
 
@@ -57,28 +57,28 @@ Note:
 
 ## Goals
 
--   Explicit over implicit
--   Predictable runtime behaviour
--   Supporting stable software development for programming at large
--   Pragmatism and easy integration
--   Approachable project
+- Explicit over implicit
+- Predictable runtime behaviour
+- Supporting stable software development for programming at large
+- Pragmatism and easy integration
+- Approachable project
 
 Many examples in this course are very small, which is why we will also
 spend time discussing the impact of many features on large projects.
 
 ## The Four Words
 
--   Safe
--   Concurrent
--   Fast
--   Pragmatic
+- Safe
+- Concurrent
+- Fast
+- Pragmatic
 
 ## Safe
 
--   Rust is memory-safe
--   No illegal memory access
--   Deallocation is automated
--   Warning: memory leaks are **safe** by that definition!
+- Rust is memory-safe
+- No illegal memory access
+- Deallocation is automated
+- Warning: memory leaks are **safe** by that definition!
 
 Note:
 
@@ -88,37 +88,37 @@ Note:
 
 ## Concurrent
 
--   "Concurrency without fear"
--   The type system detects concurrent access to data and requires
+- "Concurrency without fear"
+- The type system detects concurrent access to data and requires
     synchronisation
--   Also: Rust detects when unsynchronised access is safely possible
--   Protection from data races
+- Also: Rust detects when unsynchronised access is safely possible
+- Protection from data races
 
 ## Fast
 
--   These properties are guaranteed at compile time and have no runtime
+- These properties are guaranteed at compile time and have no runtime
     cost!
--   Optimizing compiler based on LLVM
--   Features with runtime cost are explicit and hard to activate "by
+- Optimizing compiler based on LLVM
+- Features with runtime cost are explicit and hard to activate "by
     accident"
--   No reflection
--   Zero-cost abstractions
--   "Pay what you use": Rust has features with a runtime cost in an
+- No reflection
+- Zero-cost abstractions
+- "Pay what you use": Rust has features with a runtime cost in an
     explicit and visible way. Unused features do not come with an
     associated cost.
 
 ## Pragmatic
 
--   User-focused tooling
--   Sublanguage for unsafe memory access and techniques to handle these
--   FFI support to interface with existing systems
--   Compiler gives helpful error messages
+- User-focused tooling
+- Sublanguage for unsafe memory access and techniques to handle these
+- FFI support to interface with existing systems
+- Compiler gives helpful error messages
 
 ## Where do Rustaceans come from?
 
 From diverse backgrounds:
 
--   Dynamic languages (JS, Rubyists and Pythonistas)
--   Functional languages like Haskell and Scala
--   C/C++
--   Safety critical systems
+- Dynamic languages (JS, Rubyists and Pythonistas)
+- Functional languages like Haskell and Scala
+- C/C++
+- Safety critical systems

--- a/training-slides/src/ownership.md
+++ b/training-slides/src/ownership.md
@@ -6,16 +6,16 @@ Ownership is the basis for the memory management of Rust.
 
 ## Rules
 
--   Every value has exactly one owner
--   Ownership can be passed on, both to functions and other types
--   The owner is responsible for removing the data from memory
--   The owner always has full control over the data and can mutate it
+- Every value has exactly one owner
+- Ownership can be passed on, both to functions and other types
+- The owner is responsible for removing the data from memory
+- The owner always has full control over the data and can mutate it
 
 ## These Rules are
 
--   fundamental to Rust’s type system
--   enforced at compile time
--   important for optimisations
+- fundamental to Rust’s type system
+- enforced at compile time
+- important for optimisations
 
 ## Example
 
@@ -70,14 +70,14 @@ error[E0382]: use of moved value: `s`
 
 ## Background
 
-* When calling `print_string` with `s`, the value *in* `s` is *transferred* into the arguments of `print_string`.
-* At that moment, ownership passes to `print_string`. We say the function *consumed* the value.
-* The *variable binding* `s` ceases to exist, and thus `main` is not allowed to access it any more.
+- When calling `print_string` with `s`, the value *in* `s` is *transferred* into the arguments of `print_string`.
+- At that moment, ownership passes to `print_string`. We say the function *consumed* the value.
+- The *variable binding* `s` ceases to exist, and thus `main` is not allowed to access it any more.
 
 ## Mutability
 
-* The *variable binding* can be *immutable* (the default) or *mutable*.
-* If you own it, you can rebind it and change this.
+- The *variable binding* can be *immutable* (the default) or *mutable*.
+- If you own it, you can rebind it and change this.
 
 ```rust
 fn main() {
@@ -90,17 +90,17 @@ fn main() {
 
 ## Borrowing
 
-* Transferring ownership back and forth would get tiresome.
-* We can let other functions *borrow* the values we own.
-* The outcome of a *borrow* is a *reference*
-* There are two kinds of *reference* - *Shared/Immutable* and *Exclusive/Mutable*
+- Transferring ownership back and forth would get tiresome.
+- We can let other functions *borrow* the values we own.
+- The outcome of a *borrow* is a *reference*
+- There are two kinds of *reference* - *Shared/Immutable* and *Exclusive/Mutable*
 
 ## Shared References
 
-* Also called an *immutable reference*.
-* Use the `&` operator to borrow (i.e. to make a reference).
-* It's like a C pointer but with special compile-time checks.
-* Rust also allows type-conversion functions to be called when you take a reference.
+- Also called an *immutable reference*.
+- Use the `&` operator to borrow (i.e. to make a reference).
+- It's like a C pointer but with special compile-time checks.
+- Rust also allows type-conversion functions to be called when you take a reference.
 
 ## Making a Reference
 
@@ -121,8 +121,8 @@ The `_` prefix just stops a warning about us not using the variable.
 
 ## Taking a Reference
 
-* We can also say a function takes a reference
-* We use a type like `&SomeType`:
+- We can also say a function takes a reference
+- We use a type like `&SomeType`:
 
 ```rust
 fn print_string(s: &String) {
@@ -146,16 +146,16 @@ fn print_string(s: &String) {
 
 ## Exclusive References
 
-* Also called a *mutable reference*
-* Use the `&mut` operator to borrow (i.e. to make a reference)
-* Even stricter rules than the `&` references
-* Only a *mutable binding* can make a *mutable reference*
+- Also called a *mutable reference*
+- Use the `&mut` operator to borrow (i.e. to make a reference)
+- Even stricter rules than the `&` references
+- Only a *mutable binding* can make a *mutable reference*
 
 ## Exclusive Reference Rules
 
-* Must be only one exclusive reference to an object at any one time
-* Cannot have shared and exclusive references alive at the same time
-* => the compiler knows an `&mut` reference cannot alias anything
+- Must be only one exclusive reference to an object at any one time
+- Cannot have shared and exclusive references alive at the same time
+- => the compiler knows an `&mut` reference cannot alias anything
 
 # Rust forbids *shared mutability*
 
@@ -174,8 +174,8 @@ The binding for `s` now has to be mutable, otherwise we can't take a mutable ref
 
 ## Taking an Exclusive Reference
 
-* We can also say a function takes an exclusive reference
-* We use a type like `&mut SomeType`:
+- We can also say a function takes an exclusive reference
+- We use a type like `&mut SomeType`:
 
 ```rust
 fn add_excitement(s: &mut String) {
@@ -183,7 +183,7 @@ fn add_excitement(s: &mut String) {
 }
 ```
 
-## Full Example
+## Full Example 2
 
 ```rust []
 fn main() {
@@ -209,8 +209,8 @@ Try adding more excitement by calling `add_excitement` multiple times.
 | Type `i32`    | `&i32`              | `&mut i32`       | `i32`    |
 | Type `String` | `&String` or `&str` | `&mut String`    | `String` |
 
-* *Mutably Borrowing* gives more permissions than *Borrowing*
-* *Owning* gives more permissions than *Mutably Borrowing*
+- *Mutably Borrowing* gives more permissions than *Borrowing*
+- *Owning* gives more permissions than *Mutably Borrowing*
 
 Note:
 
@@ -218,9 +218,9 @@ Why are there two types of Borrowed string types (`&String` and `&str`)? The fir
 
 ## An aside: Method Calls
 
-* Rust supports *Method Calls*
-* The first argument of the method is either `self`, `&self` or `&mut self`
-* They are converted to function calls by the compiler
+- Rust supports *Method Calls*
+- The first argument of the method is either `self`, `&self` or `&mut self`
+- They are converted to function calls by the compiler
 
 ```rust []
 fn main() {
@@ -241,8 +241,8 @@ We use `Type::function()` for associated functions, and `variable.method()` for 
 
 If you want to give a function their own object, and keeps yours separate, you have two choices:
 
-* Clone
-* Copy
+- Clone
+- Copy
 
 ## Clone
 
@@ -280,9 +280,9 @@ fn main() {
 
 ## Copy
 
-* Some types, like integers and floats, are `Copy`
-* Compiler copies these objects automatically
-* If cloning is very cheap, you could make your type `Copy`
+- Some types, like integers and floats, are `Copy`
+- Compiler copies these objects automatically
+- If cloning is very cheap, you could make your type `Copy`
 
 ```rust []
 fn main() {
@@ -321,8 +321,8 @@ fn main() {
 
 ## More drop implementations:
 
-* `MutexGuard` unlocks the appropriate `Mutex` when dropped
-* `File` closes the file handle when dropped
-* `TcpStream` closes the connection when dropped
-* `Thread` detaches the thread when dropped
-* etc...
+- `MutexGuard` unlocks the appropriate `Mutex` when dropped
+- `File` closes the file handle when dropped
+- `TcpStream` closes the connection when dropped
+- `Thread` detaches the thread when dropped
+- etc...

--- a/training-slides/src/property-testing.md
+++ b/training-slides/src/property-testing.md
@@ -2,8 +2,8 @@
 
 ## This is your brain
 
--   Everything we know is subject to bias
--   Everything we build reflects these biases
+- Everything we know is subject to bias
+- Everything we build reflects these biases
 
 ## Problem:
 
@@ -13,14 +13,14 @@ Our code reflects our biases, our tests are often biased similarly
 
 Don't write tests
 
-## Solution:
+## Solution: 2
 
 Write expectations
 
 ---
 
--   Have the machine generate random test cases
--   Make beliefs explicit, force them to pay rent
+- Have the machine generate random test cases
+- Make beliefs explicit, force them to pay rent
 
 ---
 
@@ -40,7 +40,7 @@ proptest! {
 }
 ```
 
-## Crate: **proptest**
+## Crate: **proptest** 2
 
 ```console
 $ cargo test
@@ -50,7 +50,7 @@ minimal failing input: ref a = 3689348814741910324
 test result: FAILED. 0 passed; 1 failed
 ```
 
-## Crate: **proptest**
+## Crate: **proptest** 3
 
 ```console
 $ cat proptest-regressions/main.txt
@@ -110,7 +110,7 @@ proptest! {
 
 ## Miscellaneous Tips
 
--   Isolate business logic from IO concerns
--   Use `assert!` and `debug_assert!` on non-trivial things! this makes our "fuzzers" extremely effective
--   Try not to use `unwrap()` everywhere, at least use `expect("helpful message")` to speed up debugging
--   When propagating errors, include context that helps you get back to the root
+- Isolate business logic from IO concerns
+- Use `assert!` and `debug_assert!` on non-trivial things! this makes our "fuzzers" extremely effective
+- Try not to use `unwrap()` everywhere, at least use `expect("helpful message")` to speed up debugging
+- When propagating errors, include context that helps you get back to the root

--- a/training-slides/src/rust-build-time.md
+++ b/training-slides/src/rust-build-time.md
@@ -5,9 +5,9 @@
 * Cargo keeps track of changes you make and only rebuilds what is necessary
 * when building a crate `rustc` can do most of work in parallel, but some steps still require synchronization
 * depending on the type of build, times spent in different build phases may be vastly different.
-    * debug vs release
-    * various flags for `rustc` and LLVM
-    * a build from scratch vs an incremental build
+  * debug vs release
+  * various flags for `rustc` and LLVM
+  * a build from scratch vs an incremental build
 
 ## Producing a build timings report
 
@@ -30,21 +30,24 @@
 ## Reading the report
 
 * Cargo can't start building a crate until all its dependencies have been built.
-    * Cargo only waits for `rustc` to produce an LLVM IR, further compilation by LLVM can run in background (purple)
+  * Cargo only waits for `rustc` to produce an LLVM IR, further compilation by LLVM can run in background (purple)
 * a crate can't start building until its `build.rs` is built and finishes running (yellow)
 * if multiple crates depend on a single crate they often can start building in parallel
 * if a package is both a binary and a library then the binary is built after a library
-    * integration tests, examples, benchmarks, and documentation tests all produce binaries and thus take extra time to build.
+  * integration tests, examples, benchmarks, and documentation tests all produce binaries and thus take extra time to build.
 
 ## Actions you can take
 
 ## Keep your crates independent of each other
 
 * Bad dependency graph:
+
     ```text
     D -> C -> B -> A -> App
     ```
+
 * Good dependency graph (A, B, and C can be built in parallel):
+
     ```text
       /-> A  \
     D ->  B  -> App
@@ -54,11 +57,14 @@
 ## Turn off unused features
 
 * Before:
+
     ```toml
     [dependencies]
     tokio = { version = "1", features = ["full"] } # build all of Tokio                .
     ```
+
 * After:
+
     ```toml
     [dependencies]
     tokio = { version = "1", features = ["net", "io-util", "rt-multi-thread"] }
@@ -67,14 +73,15 @@
 ## Prefer pure-Rust dependencies
 
 * crate cannot be built before `build.rs` is compiled and executed
-    * crates using C-dependencies have to rely on `build.rs`
-    * `build.rs` might trigger C/C++ compilation which in turn is often slow
+  * crates using C-dependencies have to rely on `build.rs`
+  * `build.rs` might trigger C/C++ compilation which in turn is often slow
 
 * e.g.: `rustls` instead of `openssl`
 
 ## Use multi-module integration tests:
 
 * Before (3 binaries)
+
 ```text
 ├── src/
 │   └── ...
@@ -83,7 +90,9 @@
     ├── billing.rs
     └── reporting.rs
 ```
+
 * After (a single binary)
+
 ```text
 ├── src/
 │   └── ...
@@ -94,6 +103,7 @@
         ├── billing.rs
         └── reporting.rs
 ```
+
 * Also benchmark and examples
 
 ## Other tips

--- a/training-slides/src/send-and-sync.md
+++ b/training-slides/src/send-and-sync.md
@@ -4,9 +4,9 @@
 
 There are two special traits in Rust for concurrency semantics.
 
--   `Send` marks a structure safe to *send* between threads.
--   `Sync` marks a structure safe to *share* between threads.
-    -   (`&T` is `Send`)
+- `Send` marks a structure safe to *send* between threads.
+- `Sync` marks a structure safe to *share* between threads.
+  - (`&T` is `Send`)
 
 ---
 
@@ -53,7 +53,7 @@ fn main() {
 }
 ```
 
-## Example: `Rc`
+## Example: `Rc` 2
 
 ```text
 error[E0277]: the trait bound `std::rc::Rc<bool>: std::marker::Send` is not satisfied
@@ -88,7 +88,7 @@ A type `&T` can implement `Send` if the type `T` also implements `Sync`.
 unsafe impl<'a, T: Sync + ?Sized> Send for &'a T {}
 ```
 
-## Relationships
+## Relationships 2
 
 A type `&mut T` can implement `Send` if the type `T` also implements `Send`.
 
@@ -100,7 +100,7 @@ unsafe impl<'a, T: Send + ?Sized> Send for &'a mut T {}
 
 What are the consequences of having `Send` and `Sync`?
 
-## Consequences
+## Consequences 2
 
 Carrying this information at the type system level allows driving data race bugs down to a *compile time* level.
 

--- a/training-slides/src/shared-mutability.md
+++ b/training-slides/src/shared-mutability.md
@@ -13,7 +13,6 @@ These rules can be ... *bent*
 
 (but not broken)
 
-
 ## Why the rules exist...
 
 * Optimisations!
@@ -120,7 +119,7 @@ impl Post {
 }
 ```
 
-## Without `Cell`
+## Without `Cell` 2
 
 ```rust []
 fn main() {

--- a/training-slides/src/spawning-threads.md
+++ b/training-slides/src/spawning-threads.md
@@ -141,7 +141,7 @@ let thread_handle = thread::spawn(
 );
 ```
 
-## Tidying up the handle
+## Tidying up the handle 2
 
 * In Rust, functions take *expressions*
 * Blocks are expressions...

--- a/training-slides/src/start_here.md
+++ b/training-slides/src/start_here.md
@@ -28,4 +28,3 @@ graph TD;
 * **Bare-Metal Rust**: Rust on a micro-controller.
 * **Using Embassy**: Async-Rust on a micro-controller.
 * **Why Rust?**: A (stand-alone) half-day tour of Rust for decision-makers, technical leads and managers.
-

--- a/training-slides/src/std-lib-tour.md
+++ b/training-slides/src/std-lib-tour.md
@@ -64,4 +64,3 @@ fn main() {
     println!("{:?}", components);
 }
 ```
-

--- a/training-slides/src/testing.md
+++ b/training-slides/src/testing.md
@@ -10,21 +10,21 @@ Unit, integration, and documentation tests all come built-in.
 
 Tests typically end up in 1 of 4 possible locations:
 
--   Immediately beside the functionality tested or in a `tests` submodule (Unit Tests)
--   In documentation. (Documentation Test)
--   In the `tests/` directory. (Integration Tests)
+- Immediately beside the functionality tested or in a `tests` submodule (Unit Tests)
+- In documentation. (Documentation Test)
+- In the `tests/` directory. (Integration Tests)
 
 ## Unit Tests
 
--   Allows testing functionality in the same module and environment.
--   Typically exist immediately near the functionality.
--   Good for testing to make sure a single action *works*.
+- Allows testing functionality in the same module and environment.
+- Typically exist immediately near the functionality.
+- Good for testing to make sure a single action *works*.
 
-## Unit Tests
+## Unit Tests 2
 
--   Allows testing as if the functionality is being used elsewhere in the project.
--   For testing private APIs and functionality.
--   Good for testing expected processes and use cases.
+- Allows testing as if the functionality is being used elsewhere in the project.
+- For testing private APIs and functionality.
+- Good for testing expected processes and use cases.
 
 ## `tests` Submodule
 
@@ -50,7 +50,7 @@ mod tests {
 }
 ```
 
-## `tests` Submodule
+## `tests` Submodule 2
 
 ```console
 $ cargo test
@@ -62,11 +62,11 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ## Documentation Tests
 
--   Allows testing public functionality.
--   Is displayed in `rustdoc` output.
--   For demonstrating expected use cases and examples.
+- Allows testing public functionality.
+- Is displayed in `rustdoc` output.
+- For demonstrating expected use cases and examples.
 
-## Documentation Tests
+## Documentation Tests 2
 
 ```rust []
 /// ```rust
@@ -76,7 +76,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 pub enum Direction { North, South, East, West }
 ```
 
-## Documentation Tests
+## Documentation Tests 3
 
 ```console
 $ cargo test
@@ -94,12 +94,13 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ## Integration Tests
 
--   Tests as if the crate is an external dependency.
--   Intended for longer or full-function tests.
+- Tests as if the crate is an external dependency.
+- Intended for longer or full-function tests.
 
-## Integration Tests
+## Integration Tests 2
 
 .`/tests/basic.rs`
+
 ```rust ignore []
 use example::{is_north, Direction};
 
@@ -110,7 +111,7 @@ fn is_north_works() {
 }
 ```
 
-## Integration Tests
+## Integration Tests 3
 
 ```console
 $ cargo test

--- a/training-slides/src/thread-safety.md
+++ b/training-slides/src/thread-safety.md
@@ -247,4 +247,3 @@ fn main() {
     println!("value = {}", value.load(Ordering::Relaxed));
 }
 ```
-

--- a/training-slides/src/type-state.md
+++ b/training-slides/src/type-state.md
@@ -143,7 +143,7 @@ impl Pin<Input> {
 }
 ```
 
-## Preventing mis-use.
+## Preventing mis-use
 
 Who can `impl PinMode for Type`? Turns out anyone can...
 

--- a/training-slides/src/unsafe.md
+++ b/training-slides/src/unsafe.md
@@ -10,18 +10,18 @@ For that reason, Rust has the concept of "unsafe code".
 
 Unsafe code is allowed to:
 
--   freely access memory
--   dereference raw pointers
--   call external functions
--   declare values `Send` and `Sync`
--   write to unsynced global variables
+- freely access memory
+- dereference raw pointers
+- call external functions
+- declare values `Send` and `Sync`
+- write to unsynced global variables
 
 ---
 
 Not unsafe are:
 
--   conversion to raw pointers
--   memory leaks
+- conversion to raw pointers
+- memory leaks
 
 ---
 
@@ -56,10 +56,10 @@ unsafe fn deref_pointer<T: Debug>(p: *mut T) {
 
 ## Traps of `unsafe`
 
--   Not all examples are that simple. `unsafe` *must* guarantee the invariants that Rust expects.
--   This *especially* applies to ownership and mutable borrowing
--   `unsafe` can lead to a value having 2 owners -&gt; double free
--   `unsafe` can make immutable data temporarily mutable, which will lead to broken promises and tears.
+- Not all examples are that simple. `unsafe` *must* guarantee the invariants that Rust expects.
+- This *especially* applies to ownership and mutable borrowing
+- `unsafe` can lead to a value having 2 owners -&gt; double free
+- `unsafe` can make immutable data temporarily mutable, which will lead to broken promises and tears.
 
 ---
 
@@ -84,8 +84,8 @@ fn split_at_mut<T>(value: &mut [T], mid: usize) -> (&mut [T], &mut [T]) {
 
 ## Highlight unsafe code in VSCode
 
-* Will highlight which function calls are `unsafe` inside an `unsafe` block
-* Helpful for longer `unsafe` blocks
+- Will highlight which function calls are `unsafe` inside an `unsafe` block
+- Helpful for longer `unsafe` blocks
 
 ```json
 {

--- a/training-slides/src/using-cargo.md
+++ b/training-slides/src/using-cargo.md
@@ -5,8 +5,8 @@
 * Rust code is arranged into packages
 * a package is described by a `Cargo.toml` file
 * building a package can produce a single library, and 0 or more executables
-    * these are called *crates*
-    * unlike C/C++ compilers that compile code file by file, `rustc` treat all files for a crate as a single compilation unit
+  * these are called *crates*
+  * unlike C/C++ compilers that compile code file by file, `rustc` treat all files for a crate as a single compilation unit
 * Cargo calls `rustc` to build each crate in the package.
 
 ## Cargo
@@ -34,8 +34,8 @@
 * `cargo check` - only reports errors, doesn't actually compile your code
 * `cargo clippy` - runs a linter
 * `cargo test` - builds your project if necessary and runs tests
-    * by default runs unit tests, integration tests, and documentation tests
-    * you can select which tests to run
+  * by default runs unit tests, integration tests, and documentation tests
+  * you can select which tests to run
 * `cargo build --release` - produces an optimized version of your application or library
 
 ## Cargo commands (cont)
@@ -69,25 +69,30 @@ Most cargo commands accept a few common arguments:
 ## Features
 
 * allows conditional compilation
-    * support for different operating systems
-    * adapters for different libraries
-    * optional extensions
+  * support for different operating systems
+  * adapters for different libraries
+  * optional extensions
 * can expose features from transitive dependencies
 
 ## Using Features
 
 * in code:
+
     ```text
     #[cfg(feature = "json")]
     mod json_support;
     ```
+
 * in `Cargo.toml`
+
     ```toml
     [features]
     json = [] # list of features that this feature depends on
     default = [] # "json" feature is not enabled by default
     ```
+
 * when someone uses your dependency
+
     ```toml
     my-lib = { version: "1.0.0", features = ["json"] }
     ```
@@ -105,7 +110,7 @@ cargo new hello-world
     └── main.rs
 ```
 
-## Anatomy of Rust package
+## Anatomy of Rust package 2
 
 ```text
 ├── Cargo.lock

--- a/training-slides/src/wasm.md
+++ b/training-slides/src/wasm.md
@@ -53,25 +53,25 @@ This can be added through the host system in various ways.
 Rust ships 3 WASM targets:
 
 * wasm32-unknown-emscripten (legacy)
-    * ships with an implementation of libc for WASM
+  * ships with an implementation of libc for WASM
 * wasm32-unknown-unknown (stable)
-    * direct compilation to WASM, with no additional tooling
+  * direct compilation to WASM, with no additional tooling
 * wasm32-wasi (in development)
-    * WASM with support for _interface types_, a structured way of adding capabilities
+  * WASM with support for _interface types_, a structured way of adding capabilities
 
 ## Installation: `rustup` Target
 
 `rustup` allows installing multiple compilation targets.
 
 ```console
-$ rustup target install wasm32-unknown-unknown
-$ rustup target install wasm32-wasi
+rustup target install wasm32-unknown-unknown
+rustup target install wasm32-wasi
 ```
 
 ## Installing a host runtime
 
 ```console
-$ curl --proto '=https' --tlsv1.2 -sSf https://wasmtime.dev/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSf https://wasmtime.dev/install.sh | bash
 ```
 
 * Currently need building from git: https://github.com/bytecodealliance/wasmtime
@@ -90,4 +90,3 @@ Hello, world!
 ## A Rust & WASM Tutorial
 
 <https://ferrous-systems.github.io/wasm-training-2022/>
-

--- a/training-slides/src/working-with-nighly.md
+++ b/training-slides/src/working-with-nighly.md
@@ -2,10 +2,10 @@
 
 ## Why?
 
--   Dependencies may require nightly
--   Compile times and error messages are sometimes better (sometimes not)
--   There are several features which are not yet stable
--   Compiler plugins
+- Dependencies may require nightly
+- Compile times and error messages are sometimes better (sometimes not)
+- There are several features which are not yet stable
+- Compiler plugins
 
 ## Using Nightly
 
@@ -22,9 +22,9 @@ Features are gated behind "Feature Flags" which are enabled project wide.
 
 Some examples:
 
--   `asm` which provides inline assembly support
--   `no_std` which disables implict `extern crate std`
--   `inclusive_range`, similar to the stable `exclusive_range`
+- `asm` which provides inline assembly support
+- `no_std` which disables implict `extern crate std`
+- `inclusive_range`, similar to the stable `exclusive_range`
 
 ## Enabling Features
 
@@ -38,9 +38,9 @@ To enable a feature, add the following line into `src/main.rs` (for executables)
 
 Compiler Plugins add additional capabilities to Rust. For example:
 
--   (Previously) custom derive
--   Linters
--   Libraries like [`regex_macros`](https://github.com/rust-lang/regex#usage-regex-compiler-plugin)
+- (Previously) custom derive
+- Linters
+- Libraries like [`regex_macros`](https://github.com/rust-lang/regex#usage-regex-compiler-plugin)
 
 ## Enabling Compiler Plugins
 


### PR DESCRIPTION
Fixed a bunch of nits the VSCode MarkdownLint extension had.

This sped up my editing experience a bit and I think the team should default to using it tbh.