### PR TITLE
Fix link typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can:
 
 * Browse [the chapters of the book on Github](./training-slides/src/SUMMARY.md)
 * Clone the repo, and build the book (see [Building the material locally](#building-the-material-locally))
-* Download the slides in both slide-deck and book format, from the [releases area](https://github.com/ferrous-systems/rust-exercises/releases)
+* Download the slides in both slide-deck and book format, from the [releases area](https://github.com/ferrous-systems/rust-training/releases)
 
 # Building the material locally
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Ferrous Systems offers a large Rust curriculum for both beginner and advanced Ru
 
 Ferrous Systems specialises in custom, topic focused workshops for enterprises starting or expanding their use of Rust. Supplemental to our courses, we offer ongoing help and feedback.
 
-# Overview
+## Overview
 
 The materials are presented as a set of small, self-contained lessons on a specific topic. Note that lessons might be revised, extended, or removed, when necessary to keep material up to date or relevant to new audiences.
 
 We assemble these lessons into various programmes for our commercial trainings. We can also provide custom lessons - please [reach out](https://ferrous-systems.com/contact) if that is of interest.
 
-# Reading the material
+## Reading the material
 
 This material is organised as an [`mdbook`](https://crates.io/crates/mdbook), which we also render to [`reveal.js`](https://revealjs.com) slides using an open-source tool we wrote called [`mdslides`](https://crates.io/crates/mdslides).
 
@@ -24,7 +24,7 @@ You can:
 * Clone the repo, and build the book (see [Building the material locally](#building-the-material-locally))
 * Download the slides in both slide-deck and book format, from the [releases area](https://github.com/ferrous-systems/rust-training/releases)
 
-# Building the material locally
+## Building the material locally
 
 This slide deck is an [`mdbook`](https://crates.io/crates/mdbook) that is also converted into slides using a tool we wrote called [`mdslides`](https://crates.io/crates/mdslides).
 
@@ -77,13 +77,13 @@ httplz ./slides
 # Both serve on http://localhost:8000
 ```
 
-# Credits
+## Credits
 
 The development of this course is financed by Ferrous Systems. They are open sourced as a contribution to the growth of the Rust language.
 
 If you wish to fund further development of the course, [book a training](https://ferrous-systems.com/training)!
 
-# License
+## License
 
 [![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)](http://creativecommons.org/licenses/by-sa/4.0/)
 

--- a/training-slides/src/glossary.md
+++ b/training-slides/src/glossary.md
@@ -16,4 +16,3 @@ These are some of the terms we will be using throughout our training.
 |                                Quizzes                                | Mini-tests of the training material                                                           |
 |                             Ice Breakers                              | Brief warm-up activities to get the training started, usually short Questions                 |
 | [Training Material](https://github.com/ferrous-systems/rust-training) | These training materials                                                                      |
-


### PR DESCRIPTION
Fix the link to the release area. Must have been a copy-pasta error from when we did exercises first?

Also resolved some markdown lints.

Noted in https://github.com/ferrous-systems/mdslides/issues/16