### PR TITLE
Typos

### DIFF
--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -74,7 +74,7 @@ Topics about using Rust on ARM Cortex-M Microcontrollers (and similar). Requires
 
 * [Overview of Bare-Metal Rust](./rust-bare-metal.md)
 * [Booting a Cortex-M Microcontroller (TBC)](./cortex-m-booting.md)
-* [Execptions and Interrupts on a Cortex-M Microcontroller (TBC)](./cortex-m-exceptions-interrupts.md)
+* [Exceptions and Interrupts on a Cortex-M Microcontroller (TBC)](./cortex-m-exceptions-interrupts.md)
 * [PACs and svd2rust](./pac-svd2rust.md)
 * [Writing Drivers](./writing-drivers.md)
 * [The Embedded HAL and its implementations](./embedded-hals.md)

--- a/training-slides/src/collections.md
+++ b/training-slides/src/collections.md
@@ -190,7 +190,7 @@ The second green object is the literal we gave to println - `s = `
 
 * A growable collection of `char`
 * Actually stored as a `Vec<u8>`, with UTF-8 encoding
-* You cannot acccess characters by index (only bytes)
+* You cannot access characters by index (only bytes)
   * But you never really want to anyway
 
 ```mermaid
@@ -267,7 +267,7 @@ fn main() {
 * Cannot borrow it as a single `&[T]` slice without moving items around
 * Not great for insertion in the middle
 * Everything must be of the same type
-* Indicies are always `usize`
+* Indices are always `usize`
 
 ## HashMap ([docs](https://doc.rust-lang.org/std/collections/struct.HashMap.html))
 
@@ -400,6 +400,6 @@ in half.
 The 🤔 for indexing VecDeque is because you might have to get the contents in
 two pieces (i.e. as two disjoint slices) due to wrap-around.
 
-Tecnically you *can* insert into the middle of a Vec or a String, but we're
+Technically you *can* insert into the middle of a Vec or a String, but we're
 talking about 'cheap' insertions that don't involve moving too much stuff
 around.

--- a/training-slides/src/dynamic-dispatch.md
+++ b/training-slides/src/dynamic-dispatch.md
@@ -48,7 +48,7 @@ impl Operation {
 
 ## Recommendation
 
-Try to minimise repeated matches on the Enum, if not strictly necessary.
+Try to minimize repeated matches on the Enum, if not strictly necessary.
 
 ## Trait Objects
 

--- a/training-slides/src/error-handling.md
+++ b/training-slides/src/error-handling.md
@@ -117,7 +117,7 @@ Note:
 
 This was added in Rust 1.39.
 
-The ? operator will evalulate to the `Ok` value if the `Result` is `Ok`, and it will cause an early return with the error value if it is `Err`. It will also call `.into()` to perform a type conversion if necessary (and if possible).
+The ? operator will evaluate to the `Ok` value if the `Result` is `Ok`, and it will cause an early return with the error value if it is `Err`. It will also call `.into()` to perform a type conversion if necessary (and if possible).
 
 ## What kind of Error?
 
@@ -159,7 +159,7 @@ Setting `E` to be `String` lets you make up text at run-time:
 
 ## Using enums as the Err Type
 
-An `enum` is ideal to express *one* of a number of differerent *kinds* of thing:
+An `enum` is ideal to express *one* of a number of different *kinds* of thing:
 
 ```rust
 /// Represents the ways this module can fail

--- a/training-slides/src/ffi.md
+++ b/training-slides/src/ffi.md
@@ -29,7 +29,7 @@ Clearly these two compilers must agree, otherwise the callee will not receive th
 
 x86 is ~40 years old and many standards exist on how to do this. See https://en.wikipedia.org/wiki/X86_calling_conventions#Historical_background.
 
-AMD64 is only ~15 years old, and there are two standards - the Microsoft one for Windows, and the Linux one (which is based on System V UNIX).  
+AMD64 is only ~15 years old, and there are two standards - the Microsoft one for Windows, and the Linux one (which is based on System V UNIX).
 
 ---
 
@@ -113,7 +113,7 @@ extern "C" fn magicadder_process_value(adder: *const MagicAdder, value: u32) -> 
 
 Note:
 
-The `.as_ref()` method on pointers *requires* that the pointer either be null, or that it point at a valid, aligned, fully initialised object. If they just feed you a random integer, bad things will happen, and we can't tell if they've done that!
+The `.as_ref()` method on pointers *requires* that the pointer either be null, or that it point at a valid, aligned, fully initialized object. If they just feed you a random integer, bad things will happen, and we can't tell if they've done that!
 
 ## Matching C header
 
@@ -233,7 +233,7 @@ You cannot do `extern "C" fn some_function();` with no function body - you must 
 
 ## Primitive types
 
-Some type conversions can be infered by the compiler.
+Some type conversions can be inferred by the compiler.
 
 * `c_uint` ↔ `u32`
 * `c_int` ↔ `i32`

--- a/training-slides/src/heap.md
+++ b/training-slides/src/heap.md
@@ -53,7 +53,7 @@ z @ 0x555829f269d0
 
 The first `z @` line is the `struct String { ... }` itself. The second `z @` line are the bytes the `String` contains. They have a different addresses because they are in the heap and not on the stack.
 
-If you run it multiple times, you will get different results. This is due to the Operating System randomising the virtual addresses used for the stack and the heap, to make security vulnerabilities harder to exploit.
+If you run it multiple times, you will get different results. This is due to the Operating System randomizing the virtual addresses used for the stack and the heap, to make security vulnerabilities harder to exploit.
 
 On macOS, you can run `vmmap <pid>` to print the addresses for each region. On Linux you can use `pmap <pid>`, or you could add something like:
 

--- a/training-slides/src/overview.md
+++ b/training-slides/src/overview.md
@@ -43,7 +43,7 @@ Rust is an empathic systems programming language that is determined to not let y
 ## Release Method
 
 -   Nightly releases
--   experimental features are only present on nighly releases
+-   experimental features are only present on nightly releases
 -   Every 6 weeks, the current nightly is promoted to beta
 -   After 6 weeks of testing, beta becomes stable
 -   Guaranteed backwards-compatibility
@@ -90,8 +90,8 @@ Note:
 
 -   "Concurrency without fear"
 -   The type system detects concurrent access to data and requires
-    synchronisation
--   Also: Rust detects when unsynchronised access is safely possible
+    synchronization
+-   Also: Rust detects when unsynchronized access is safely possible
 -   Protection from data races
 
 ## Fast

--- a/training-slides/src/ownership.md
+++ b/training-slides/src/ownership.md
@@ -15,7 +15,7 @@ Ownership is the basis for the memory management of Rust.
 
 -   fundamental to Rust’s type system
 -   enforced at compile time
--   important for optimisations
+-   important for optimizations
 
 ## Example
 

--- a/training-slides/src/shared-mutability.md
+++ b/training-slides/src/shared-mutability.md
@@ -16,7 +16,7 @@ These rules can be ... *bent*
 
 ## Why the rules exist...
 
-* Optimisations!
+* Optimizations!
 * It is *undefined behaviour* (UB) to have multiple `&mut` references to the *same* object at the *same* time
 * You *must* avoid UB
 
@@ -52,7 +52,7 @@ fn main() {
 
 Note:
 
-The `UnsafeCell::get(&self) -> *mut T` method is safe, but deferencing the pointer (or converting it to a `&mut` reference) is unsafe because a human must verify there is no aliasing.
+The `UnsafeCell::get(&self) -> *mut T` method is safe, but dereferencing the pointer (or converting it to a `&mut` reference) is unsafe because a human must verify there is no aliasing.
 
 ## Can we be safer?
 

--- a/training-slides/src/start_here.md
+++ b/training-slides/src/start_here.md
@@ -23,7 +23,7 @@ graph TD;
 * **Applied Rust**: Using Rust with Windows, macOS or Linux.
 * **Advanced Rust**: Deep-dives into specific topics.
 * **Async Rust**: Futures, Polling, Tokio, and all that jazz.
-* **Ferrocene**: Working with our qualfied toolchain
+* **Ferrocene**: Working with our qualified toolchain
 * **No-Std Rust**: Rust without the Standard Library.
 * **Bare-Metal Rust**: Rust on a micro-controller.
 * **Using Embassy**: Async-Rust on a micro-controller.

--- a/training-slides/src/working-with-nighly.md
+++ b/training-slides/src/working-with-nighly.md
@@ -23,7 +23,7 @@ Features are gated behind "Feature Flags" which are enabled project wide.
 Some examples:
 
 -   `asm` which provides inline assembly support
--   `no_std` which disables implict `extern crate std`
+-   `no_std` which disables implicit `extern crate std`
 -   `inclusive_range`, similar to the stable `exclusive_range`
 
 ## Enabling Features
@@ -52,8 +52,8 @@ To enable a compiler plugin add the following line into `src/main.rs` (for execu
 
 ## Warning
 
-It is unknown, when and if ever compiler-plugins will be stabilised.
+It is unknown, when and if ever compiler-plugins will be stabilized.
 
 ## Stable development on nightly
 
-It is recommendable to use a nighly compiler close to the release version used.
+It is recommendable to use a nightly compiler close to the release version used.


### PR DESCRIPTION
- fix most of typos
- enforce Oxford spelling (`-ize` and `-ization`)
- did not touch British spelling, though `colour` in *code* looks very unnatural
