### PR TITLE
Advanced Rust

### DIFF
--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -60,6 +60,7 @@ Topics that go beyond [Applied Rust](#applied-rust).
 
 * [Strategies for organizing application memory in Rust](./memory-strategies.md)
 * [Deconstructing Send, Arc, and Mutex](./deconstructing-send-arc-mutex.md)
+* [Deconstructing thread::scope](./deconstructing-thread-scope.md)
 
 # No-Std Rust
 

--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -64,12 +64,14 @@ Rust for the Linux Kernel and other no-std environments with an pre-existing C A
 * [Foreign Function Interface](./ffi.md)
 * [Working with Nightly](./working-with-nighly.md)
 
+<!--
 ## Under development
 
 * [Overview of no-std Rust]()
 * [Rust in the Linux Kernel]()
 * [Rust on an RTOS]()
 * [Writing a new target]()
+-->
 
 # Bare-Metal Rust
 
@@ -82,15 +84,19 @@ Topics about using Rust on ARM Cortex-M Microcontrollers (and similar). Requires
 * [The Embedded HAL and its implementations](./embedded-hals.md)
 * [Board Support Crates](./board-support.md)
 
+<!--
 ## Under development
 
 * [Exceptions and Interrupts on a Cortex-M Microcontroller]()
 * [Using RTIC v1]()
+-->
 
 # Ferrocene
 
 Topics around [Ferrocene](https://ferrous-systems.com/ferrocene/), the qualified toolchain for writing safety-critical systems in Rust.
 
+<!--
 ## Under development
 
 * [Installing and Using Ferrocene]()
+-->

--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -56,6 +56,10 @@ Topics that go beyond [Applied Rust](#applied-rust).
 * [Using Types to encode State](./type-state.md)
 * [WASM](./wasm.md)
 
+## Under development
+
+* [Strategies for organizing application memory in Rust](./memory-strategies.md)
+
 # No-Std Rust
 
 Rust for the Linux Kernel and other no-std environments with an pre-existing C API. Requires [Applied Rust](#applied-rust).

--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -59,6 +59,7 @@ Topics that go beyond [Applied Rust](#applied-rust).
 ## Under development
 
 * [Strategies for organizing application memory in Rust](./memory-strategies.md)
+* [Deconstructing Send, Arc, and Mutex](./deconstructing-send-arc-mutex.md)
 
 # No-Std Rust
 

--- a/training-slides/src/deconstructing-send-arc-mutex.md
+++ b/training-slides/src/deconstructing-send-arc-mutex.md
@@ -1,0 +1,400 @@
+<!-- markdownlint-disable MD031 MD033 MD037 -->
+# Deconstructing Send, Arc, and Mutex
+
+## `tread::spawn` Function
+
+```rust ignore
+pub fn spawn<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T,
+    F: Send + 'static,
+    T: Send + 'static,
+{
+    // ...
+}
+```
+
+## Quick Primer on Rust Closures
+
+* 3 categories of data
+  * data the closure *closes over* / *captures*: **Upvars**
+    * convenient compiler terminology
+    * not represented by closure type
+  * parameters
+  * returned value
+
+```rust ignore
+let upper_threshold = 20;
+let outliers: Vec<_> = data.iter().copied().filter(|n| -> bool {
+    // `n` is a parameter, `upper_threshold` is an *upvar*
+    n >= upper_threshold
+}).collect();
+```
+
+## Spawn closure type
+
+* `F: FnOnce() -> T`
+  * closure doesn't accept any parameters
+  * closure can *consume upvars* ("FnOnce")
+* `F: Send + 'static`
+  * applies to *upvars*
+* `T: Send + 'static`
+  * applies to returned value
+
+## `T: 'static`
+
+One of two cases:
+
+* the type doesn't have any references inside ("Owned data")
+  * `struct User { name: String }`
+* the references inside the type are `'static`
+  * `struct Db { connection_string: &'static str }`
+
+## Why `F: 'static` and `T: 'static`?
+
+* applies to data passed from parent thread to child thread or vise versa
+* prevents passing references to local variables
+  * one thread can finish before the other and such references may become invalid
+  * `+ 'static` lets borrow checker detect these situations at compile time
+
+## `T: Send`
+
+`pub unsafe auto trait Send { }`
+
+* `auto` means all types get this trait automatically
+  * opt-out instead of opt-in
+* various types in standard library implement `Send` or `!Send`
+* `unsafe` means you have to put `unsafe` keyword in front of `impl` when implementing `Send` or `!Send`
+  * precaution measure
+
+## Why would one implement `Send` or `!Send`
+
+* Rust pointers (`*const T`, `*mut T`, `NonNull<T>`) are `!Send`
+  * Use-case: what if the pointer comes from FFI library that assumes that all functions using this pointer are called from the same thread?
+* `Arc` has a `NonNull<..>` inside and becomes `!Send` automatically
+  * to override this behavior `Arc` explicitly implements `Send`
+
+## `Send` in `thread::spawn` Function
+
+`F: Send` and `T: Send` means that all data traveling from the parent thread to child thread has to be marked as `Send`
+
+* Rust compiler has to inherent knowledge of threads, but the use of marker traits and lifetime annotations let the type / borrow checker prevent data race errors
+
+## Sharing data between threads
+
+## Example: Message Log for TCP Echo Server
+
+```rust ignore
+use std::{
+    io::{self, BufRead as _, Write as _},
+    net, thread,
+};
+
+fn handle_client(stream: net::TcpStream) -> Result<(), io::Error> {
+    let mut writer = io::BufWriter::new(&stream);
+    let reader = io::BufReader::new(&stream);
+    for line in reader.lines() {
+        let line = line?;
+        writeln!(writer, "{}", line)?;
+        writer.flush()?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), io::Error> {
+    let listener = net::TcpListener::bind("0.0.0.0:7878")?;
+
+    for stream in listener.incoming() {
+        let stream = stream?;
+        thread::spawn(|| {
+            let _ = handle_client(stream);
+        });
+    }
+    Ok(())
+}
+```
+
+## Task
+
+* create a log of lengths of all lines coming from all streams
+* `let mut log = Vec::<usize>::new();`
+* `log.push(line.len());`
+
+## "Dream" API
+
+```rust ignore
+fn handle_client(stream: net::TcpStream, log: &mut Vec<usize>) -> Result<(), io::Error> {
+    //
+    for line in ... {
+        log.push(line.len());
+        //
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), io::Error> {
+    let mut log = vec![];
+
+    for stream in listener.incoming() {
+        //
+        thread::spawn(|| {
+            let _ = handle_client(stream, &mut log);
+        });
+    }
+    Ok(())
+}
+```
+
+## Errors
+
+<pre>
+error[E0373]: closure may outlive the current function, but it borrows `log`,
+which is owned by the current function
+  --> src/main.rs:26:23
+   |
+26 |         thread::spawn(|| {
+   |                       ^^ may outlive borrowed value `log`
+27 |             let _ = handle_client(stream, &mut log);
+   |                                                --- `log` is borrowed here
+   |
+note: function requires argument type to outlive `'static`
+</pre>
+
+## Life-time problem
+
+Problem:
+
+* local data may be cleaned up prematurely
+
+Solution:
+
+* move the decision when to clean the data from compile-time to runtime
+  * use reference-counting
+
+## Attempt 1: `Rc`
+
+* `let mut log = Rc::new(vec![]);`
+* `let mut thread_log = log.clone()` now does't clone the data, but simply increases the reference count
+  * both variables now have *owned* type, and satisfy `F: 'static` requirement
+
+```text
+error[E0277]: `Rc<Vec<usize>>` cannot be sent between threads safely
+```
+
+## `Rc` in Rust Standard Library
+
+* uses `usize` for reference counting
+* explicitly marked as `!Send`
+
+```rust ignore
+pub struct Rc<T> {
+    ptr: NonNull<RcBox<T>>,
+}
+
+impl<T> !Send for Rc<T> {}
+
+struct RcBox<T> {
+    strong: Cell<usize>,
+    weak: Cell<usize>,
+    value: T,
+}
+```
+
+## `Arc` in Rust Standard Library
+
+* uses `AtomicUsize` for reference counting
+* explicitly marked as `Send`
+
+```rust ignore
+pub struct Arc<T> {
+    ptr: NonNull<ArcInner<T>>,
+}
+
+impl<T> Send for Arc<T> {}
+
+struct ArcInner<T: ?Sized> {
+    strong: atomic::AtomicUsize,
+    weak: atomic::AtomicUsize,
+    data: T,
+}
+```
+
+## `Rc` vs `Arc`
+
+* `Arc` uses `AtomicUsize` for reference counting
+  * slower
+  * safe to increment / decrement from multiple threads
+* With the help of marker trait `Send` and trait bounds on `thread::spawn` Rust compiler *forces* you to use the correct type
+
+## `Arc` / `Rc` "transparency"
+
+```rust ignore
+let mut log = Arc::new(Vec::new());
+// how does this code work?
+log.len();
+// and why doesn't this work?
+log.push(1);
+```
+
+## `Deref` and `DerefMut` traits
+
+```rust ignore
+pub trait Deref {
+    type Target: ?Sized;
+    fn deref(&self) -> &Self::Target;
+}
+
+pub trait DerefMut: Deref {
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+```
+
+## `Deref` coercions
+
+* `Deref` can convert a `&self` reference to a reference of another type
+  * conversion function call can be inserted by the compiler for you automatically
+  * in most cases the conversion is a no-op or a fixed pointer offset
+  * deref functions can be inlined
+* `Target` is an associated type
+  * can't `deref()` into multiple different types
+* `DerefMut: Deref` allows the later to reuse the same `Target` type
+  * read-only and read-write references coerce to the references of the same type
+
+## `Arc` / `Rc` "transparency" with `Deref`
+
+```rust ignore
+let mut log = Arc::new(Vec::new());
+// Arc<T> implements `Deref` from `&Arc<T> into `&T`
+log.len();
+// the same as
+Vec::len(<Arc<_> as Deref>::deref(&log));
+
+// Arc<T> DOES NOT implement `DerefMut`
+// log.push(1);
+
+// the line above would have expanded to:
+// Vec::push(<Arc<_> as DerefMut>::deref_mut(&mut log), 1);
+```
+
+## `Arc` and mutability
+
+* lack of `impl DerefMut for Arc` prevents accidental creation of multiple `&mut` to underlying data
+* the solution is to move mutability decision to runtime
+
+```rust ignore
+let log = Arc::new(Mutex::new(Vec::new()));
+```
+<p>&nbsp<!-- run-button placeholder --></p>
+
+* `Arc` guarantees availability of data in memory
+  * prevents memory form being cleaned up prematurely
+* `Mutex` guarantees exclusivity of mutable access
+  * provides a single `&mut` to underlying data simultaneously
+
+## `Mutex` in Action
+
+* `log` is passed as `&` and is `deref`-ed from `Arc` by the compiler
+* `mut`ability is localized to a local `guard` variable
+  * `Mutex::lock` method takes `&self`
+* `MutexGuard` implements `Deref` *and* `DerefMut`!
+* `'_` lifetime annotation is needed only because guard struct has a `&Mutex` inside
+
+```rust ignore
+fn handle_client(..., log: &Mutex<Vec<usize>>) -> ... {
+    for line in ... {
+        let mut guard: MutexGuard<'_, Vec<usize>> = log.lock().unwrap();
+        guard.push(line.len());
+        // line above expands to:
+        // Vec::push(<MutexGuard<'_, _> as DerefMut>::deref_mut(&mut guard), line.len());
+        writeln!(writer, "{}", line)?;
+        writer.flush()?;
+    }
+}
+```
+
+## `Mutex` locking and unlocking
+
+* we `lock` the mutex for exclusive access to underlying data at runtime
+* old C APIs used a pair of functions to lock and unlock the mutex
+* `MutexGuard` does unlocking automatically when is dropped
+  * time between guard creation and drop is called *critical section*
+
+## Lock Poisoning
+
+* `MutexGuard` in its `Drop` implementation checks if it is being dropped normally or during a `panic` unwind
+  * in later case sets a poison flag on the mutex
+* calling `lock().unwrap()` on a poisoned Mutex causes `panic`
+  * if the mutex is *"popular"* poisoning can cause many application threads to panic, too.
+* poisoning API is *problematic*
+  * `PoisonError` doesn't provide information about the panic that caused the poisoning
+  * no way to recover and revive the mutex (stays poisoned forever)
+    * `PoisonError::into_inner` *can* produce a guard even for poisoned mutexes
+
+## Critical Section "Hygiene"
+
+* keep it short to reduce the window when mutex is locked
+* avoid calling functions that can panic
+* using a named variable for Mutex guard helps avoiding unexpected temporary lifetime behavior
+
+```rust ignore
+fn handle_client(..., log: &Mutex<Vec<usize>>) -> ... {
+    for line in ... {
+        {
+            let mut guard: MutexGuard<'_, Vec<usize>> = log.lock().unwrap();
+            guard.push(line.len());
+        } // critical section ends here, before all the IO
+        writeln!(writer, "{}", line)?;
+        writer.flush()?;
+    }
+}
+```
+<p>&nbsp<!-- run-button placeholder --></p>
+
+* `drop(guard)` also works, but extra block nicely highlights the critical section
+
+## Lessons Learned
+
+* careful use of traits and trait boundaries lets Rust compiler detect problematic multithreading code at compile time
+* `Arc` and `Mutex` let the program ensure data availability and exclusive mutability at runtime where the compiler can't predict the behavior of the program
+* `Deref` coercions make concurrency primitives virtually invisible and transparent to use
+* **Make invalid state unrepresentable**
+
+## Full Example
+
+```rust ignore
+use std::{
+    io::{self, BufRead as _, Write as _},
+    net,
+    sync::{Arc, Mutex},
+    thread,
+};
+
+fn handle_client(stream: net::TcpStream, log: &Mutex<Vec<usize>>) -> Result<(), io::Error> {
+    let mut writer = io::BufWriter::new(&stream);
+    let reader = io::BufReader::new(&stream);
+    for line in reader.lines() {
+        let line = line?;
+        {
+            let mut guard = log.lock().unwrap();
+            guard.push(line.len());
+        }
+        writeln!(writer, "{}", line)?;
+        writer.flush()?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), io::Error> {
+    let log = Arc::new(Mutex::new(vec![]));
+    let listener = net::TcpListener::bind("0.0.0.0:7878")?;
+
+    for stream in listener.incoming() {
+        let stream = stream?;
+        let thread_log = log.clone();
+        thread::spawn(move || {
+            let _ = handle_client(stream, &thread_log);
+        });
+    }
+    Ok(())
+}
+```

--- a/training-slides/src/deconstructing-thread-scope.md
+++ b/training-slides/src/deconstructing-thread-scope.md
@@ -1,0 +1,30 @@
+# Deconstructing `thread::scope`
+
+## `thread::scope`
+
+```rust ignore
+pub fn scope<'env, F, T>(f: F) -> T
+where
+    F: for<'scope> FnOnce(&'scope Scope<'scope, 'env>) -> T,
+{
+    // ...
+}
+
+pub struct Scope<'scope, 'env: 'scope> {
+    data: Arc<ScopeData>,
+    scope: PhantomData<&'scope mut &'scope ()>,
+    env: PhantomData<&'env mut &'env ()>,
+}
+
+impl<'scope, 'env> Scope<'scope, 'env> {
+    pub fn spawn<F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
+    where
+        F: FnOnce() -> T + Send + 'scope,
+        T: Send + 'scope,
+    {
+        // ...
+    }
+}
+```
+
+## TODO

--- a/training-slides/src/memory-strategies.md
+++ b/training-slides/src/memory-strategies.md
@@ -1,0 +1,214 @@
+<!-- markdownlint-disable MD031 MD033 -->
+# Strategies for organizing memory in Rust applications
+
+## Part 1: Working with Large long-lived mutating object graphs
+
+## Two types of changes
+
+* Topology changes
+* Node content changes
+
+## Naïve approach
+
+* `Option<T>`
+* `Cell<T>` and `RefCell<T>`
+
+## `Option<T>`
+
+* access requires `if let`
+* operations via `Option` methods introduce closures with own scopes
+  * cross-scope data access is hard
+  * doesn't play well with `Result` and `?`
+
+## Aside: Optional Chaining in Rust
+
+Other languages have "optional chaining operator"
+
+```rust ignore
+fn perform_action() -> Result<..., ...> {
+    // won't work, because the outer function returns Result, not Option
+    let data: Option<...> = deeply.nested()?.lookup()?.of?.optional?.data();
+}
+```
+
+## Aside: Optional Chaining in Rust, Recipe
+
+by extracting lookup chain into a function that returns Option we enable `?` to act as an optional chaining operator in Rust
+
+```rust ignore
+fn deeply_nested_lookup(data: &Data) -> Option<NestedComponent> {
+    // notice how we can mix and match method calls and field accesses
+    deeply.nested()?.lookup()?.of?.optional?.data()
+}
+
+fn perform_action() -> Result<..., ...> {
+    // now works
+    let data: Option<...> = deeply_nested_lookup(&data);
+}
+```
+
+## `Cell` and `RefCell`
+
+* many `Cell` / `RefCell` methods can `panic!`
+* `try_borrow_mut` gives a `Result`
+  * how to handle `Err` case?
+* harder to reason about mutability
+    ```rust ignore
+    fn does_this_fn_mutate_data_or_not(data: &Data) -> Result<...> {        //.
+        if let Ok(item) = data.item.try_borrow_mut() {
+            item.counter += 1;
+        }
+    }
+    ```
+
+## Alternatives to `Option+RefCell`
+
+* strict hierarchy and common-root sharing
+* entity-component systems
+* query systems
+
+## Strict Hierarchy and Common-Root Sharing
+
+* represent your data as a tree
+* prefer owned data
+* no cross-references (parent, siblings, etc.)
+* the root is owned by a top-level function and is mutable
+  * `main`, `thread::spawn` closure, etc.
+
+## Common-Root Sharing
+
+when a mutation is performed and it needs mutable access to some sub-tree `A` and read-only access to other sub-trees `B` and `C`
+
+* a common root for all subtrees `A`, `B`, and `C` is selected
+* `&mut CommonRoot` is passed to the mutating function
+
+## Common-Root Sharing: Pros
+
+* functions work with plain Rust structures
+  * no internal references in those structures
+  * exclusive access
+* all references to sub-components of the tree are created inside the function
+  * straightforward borrow checker interactions
+* mutability is declared in function signature
+
+## Common-Root Sharing: Cons
+
+* over-elevated access rights
+  * when a function needs a mutable access to a small portion of the tree it may be receiving a mutable reference to much larger subtree
+  * over-sharing can propagate up the function call chain and introduce access rights conflicts over time
+* strict topology rules (no cross-references) limit applicability of the pattern
+  * can provoke data over-cloning
+
+## References without References
+
+Handle
+
+* an *id* of an object
+* instead of storing references to objects store their ids
+
+## Type-safe Handles
+
+```rust ignore
+struct Handle<T>(usize, PhantomData<T>);
+
+// derive macro generates `impl<T: Clone> Clone for Handle<T>`
+// that's why we use explicit implementations for Clone and Copy
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        Self(self.0, PhantomData)
+    }
+}
+impl<T> Copy for Handle<T> {}
+
+impl<T> From<usize> for Handle<T> {
+    fn from(value: usize) -> Self {
+        Handle(value, PhantomData)
+    }
+}
+```
+
+## Use of Type-Safe Handles
+
+```rust ignore
+struct User { id: Handle<User> }
+struct Document { id: Handle<Document> }
+
+struct Group { users: Vec<Handle<User>> }
+
+fn main() {
+    let user = User { id: Handle::from(1) };
+    let document = Document { id: Handle::from(1) };
+    let mut group = Group { users: vec![] };
+    group.users.push(user.id);
+    // fails with mismatch types
+    // group.users.push(document.id);
+}
+```
+
+## Handle Pros
+
+* Structures holding handles don't hold references
+  * no lifetimes involved
+  * no cross-references within larger structures
+    * can use common-roots sharing!
+* In Rust typed handles prevent invalid associations
+
+## Handle Cons
+
+* Data access needs to perform handle lookups:
+  * `all_users.get(user_handle)`
+  * lookup failures have to be handles explicitly (`Option`)
+* Object lifetime management can be complicated
+  * explicit cleanups
+  * reference counting
+    * may accidentally introduce `Rc<RefCell<T>>` patterns even for simplest lookups
+
+## Where the Data is Stored?
+
+* Maps:
+    ```rust ignore
+    // same for other types
+    let mut user_storage: HashMap<Handle<User>, User> = HashMap.new();
+    // potentially need to provide multiple maps for operations
+    invalidate_sessions(&mut session_storage, &mut user_storage, &cut_off_date);
+    ```
+    <p>&nbsp<!-- run-button placeholder --></p>
+
+* "database" or "storage"
+    ```rust ignore
+    invalidate_sessions(&mut db, &cut_off_date);
+    // presumable storage API
+    db.get_mut::<Session>(&session_handle);
+    ```
+    <p>&nbsp<!-- run-button placeholder --></p>
+    * associate multiple structs with the same handle (compartmentalization of mutability)
+
+## TODO: Salsa
+
+## TODO: ECS
+
+## Part 2: Sharing Data between Threads
+
+## Multithreading Influence on Data Design
+
+* `thread::spawn` requires data to be `Send` and `'static`
+* `Arc` vs `Rc`, `Mutex` vs `RefCell`
+* async runtimes often run tasks on a thread pool
+  * fragments of the same async function may be running on different threads
+  * same `Send + Sync + 'static` requirements often apply
+
+## Types of Application Memory
+
+* short-lived single task
+  * local variables
+  * data transfer objects
+* long-lived single task
+  * web requests
+  * database transactions
+* long-lived, shared, and read-only
+  * configuration
+* **long-lived, shared between tasks**
+  * user sessions
+  * database connection pool
+
+## TODO Long-lived Shared Mutable Data


### PR DESCRIPTION
- hide Under development sections, as they break mdslides
- wip: memory management in Rust applications
- Deconstructing Send, Arc, and Mutex
- wip: deconstructing `thread::scope`
