### PR TITLE
Cleaning up the svd2rust deck.

### DIFF
--- a/training-slides/src/pac-svd2rust.md
+++ b/training-slides/src/pac-svd2rust.md
@@ -13,6 +13,14 @@ provides access to the memory-mapped peripherals in your MCU.
 * Peripherals can have instances (same layout of registers, different start address)
   * UART0, UART1, etc
 
+Note:
+
+The *Universal Asynchronous Receiver Transmitter* is an IP block implementing a
+logic-level RS-232 interface, and one is fitted to basically every
+microcontroller. Also known as a *serial port*.
+
+Nordic calls their peripheral *UARTE*, with the E standing for *Easy DMA*.
+
 ## Registers
 
 * *Registers* are comprised of one or more *bitfields*.


### PR DESCRIPTION
Revised the svd2rust deck.

* Talk about *bitfields* to avoid confusion with *fields in structs*
* Update link to nrf52840 PAC
* Show ZST alternative
* Note that some RISC-V chips have SVD files