### PR TITLE
point to nrf52840-pac

### DIFF
--- a/training-slides/src/rust-bare-metal.md
+++ b/training-slides/src/rust-bare-metal.md
@@ -33,7 +33,7 @@ graph TB
     hal[MCU HAL Implementation<br/><tt>nrf52480_hal</tt>]
     lcd_driver[SPI LCD Driver<br/><tt>ssd1306</tt>]
     hal_traits[[HAL Traits<br/><tt>embedded_hal</tt>]]
-    pac[MCU PAC<br/><tt>nrf52840</tt>]
+    pac[MCU PAC<br/><tt>nrf52840-pac</tt>]
     rt[Core Runtime<br/><tt>cortex_m_rt</tt>]
     cp[Core Peripherals<br/><tt>cortex_m</tt>]
 


### PR DESCRIPTION
I this as the only outsdanding `nrf52840` -> `nrf52840-pac` link left in the slides.

Closes https://github.com/ferrous-systems/rust-training/issues/116