### PR TITLE
make mdbook test pass by not opening local files or running shell scripts on windows

### DIFF
--- a/training-slides/src/io.md
+++ b/training-slides/src/io.md
@@ -93,7 +93,7 @@ See the [std::io::File docs](https://doc.rust-lang.org/std/fs/struct.File.html#i
 ```rust []
 use std::io::BufRead;
 
-fn main() -> std::io::Result<()> {
+fn print_file() -> std::io::Result<()> {
     let f = std::fs::File::open("/etc/hosts")?;
     let reader = std::io::BufReader::new(f);
     for line in reader.lines() {

--- a/training-slides/src/std-lib-tour.md
+++ b/training-slides/src/std-lib-tour.md
@@ -36,7 +36,7 @@ Used for interacting with other executables.
 ```rust []
 use std::process::Command;
 
-fn main() {
+fn example() {
     Command::new("ls")
             .args(&["-l", "-a"])
             .spawn()


### PR DESCRIPTION
Running `mdbook test` without these changes fails and is very noisy.
We should just toggle the `ignore` feature in those blocks.