### PR TITLE
Language refreshers aka "Coming from Python" cheatsheets

### DIFF
--- a/training-slides/src/SUMMARY.md
+++ b/training-slides/src/SUMMARY.md
@@ -71,6 +71,11 @@ Rust for the Linux Kernel and other no-std environments with an pre-existing C A
 * [Rust on an RTOS]()
 * [Writing a new target]()
 
+## Noteworthy Differences with other languages
+
+* [Coming from Python](./coming-from-python.md)
+* [Coming from C++](./coming-from-cpp.md)
+
 # Bare-Metal Rust
 
 Topics about using Rust on ARM Cortex-M Microcontrollers (and similar). Requires [Applied Rust](#applied-rust).

--- a/training-slides/src/coming-from-cpp.md
+++ b/training-slides/src/coming-from-cpp.md
@@ -1,0 +1,51 @@
+# Coming from C++
+
+[Glossary](./glossary.md)
+
+# Rust Fundamentals
+
+## Overview
+## Installation
+## Basic Types
+## ontrol Flow
+## Compound Types
+## Ownership and Borrowing
+## Error Handling
+## Collections
+## Iterators
+## Imports and Modules
+## Good Design Practices
+
+# Applied Rust
+
+## Methods and Traits
+## Rust I/O Traits
+## Generics
+## Lifetimes
+## Cargo Workspaces
+## Heap Allocation
+## Shared Mutability
+## Thread Safety
+## Closures and the Fn/FnOnce/FnMut traits
+## Spawning Threads and Scoped Threads
+
+# Advanced Rust
+
+## Advanced Strings
+## Debugging Rust
+## Dependency Management with Cargo
+## Deref Coercions
+## Design Patterns
+## Documentation
+## Drop, Panic and Abort
+## Dynamic Dispatch
+## Macros
+## Property Testing
+## Rust Projects Build Time
+## Send and Sync
+## Serde
+## Testing
+## The stdlib
+## Using Cargo
+## Using Types to encode State
+## WASM


### PR DESCRIPTION
We've been missing a resource where we can point people coming in from X language help them get a good sense of the most common pitfalls they will face in Rust, per topic.

I'm proposing we take the overarching structure of the slides (delimited by Slides titles) and flesh out each section separately, per language.

I'm opening this up as a draft to see if others agree on the design of these "Coming From X" and adjust accordingly.