### PR TITLE
Clean up the FFI slides

### DIFF
--- a/example-code/build.sh
+++ b/example-code/build.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Check the example code
 pushd ./native/ffi/use-c-in-rust
 cargo build --all
+cargo test
 cargo clean
 popd
 pushd ./native/stdout

--- a/example-code/native/ffi/use-c-in-rust/build.rs
+++ b/example-code/native/ffi/use-c-in-rust/build.rs
@@ -1,7 +1,7 @@
 use cc;
 
 fn main() {
-	cc::Build::new()
-		.file("src/cool_library.c")
-		.compile("cool_library");
+    cc::Build::new()
+        .file("src/cool_library.c")
+        .compile("cool_library");
 }

--- a/example-code/native/ffi/use-c-in-rust/src/cool_library.c
+++ b/example-code/native/ffi/use-c-in-rust/src/cool_library.c
@@ -1,5 +1,15 @@
-#include <stdint.h>
-
-uint32_t cool_library_function(uint32_t x, uint32_t y) {
-	return x + y;
+/**
+ * @brief Parses a null-terminated string into an integer
+ * 
+ * @param s a null-terminated string
+ * @return the integer represented by the string, or 0 
+ */
+unsigned int cool_library_function(const char* s) {
+    unsigned int result = 0;
+    for(const char* p = s; *p; p++) {
+        result *= 10;
+        if ((*p < '0') || (*p > '9')) {  return 0; } 
+        result += (*p - '0');
+    }
+    return result;
 }

--- a/example-code/native/ffi/use-c-in-rust/src/main.rs
+++ b/example-code/native/ffi/use-c-in-rust/src/main.rs
@@ -1,10 +1,30 @@
+use std::ffi::{c_char, c_uint}; // also in core::ffi
+
 extern "C" {
-    fn cool_library_function(x: u32, y: u32) -> u32;
+    // We state that this function exists, but there's no definition.
+    // The linker looks for this 'symbol name' in the other objects
+    fn cool_library_function(p: *const c_char) -> c_uint;
 }
 
 fn main() {
-    let result: u32 = unsafe {
-        cool_library_function(6, 7)
-    };
-    println!("6 + 7 = {}", result);
+    let s = c"123";
+    let result: u32 = unsafe { cool_library_function(s.as_ptr()) };
+    println!("cool_library_function({s:?}) => {result}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_integer() {
+        let r = unsafe { cool_library_function(c"123".as_ptr()) };
+        assert_eq!(r, 123);
+    }
+
+    #[test]
+    fn invalid_integer() {
+        let r = unsafe { cool_library_function(c"x123".as_ptr()) };
+        assert_eq!(r, 0);
+    }
 }


### PR DESCRIPTION
* Switch to std::ffi, not std::os::raw
* Clarify type conversions / type aliases
* Change C example to take a null-terminated string
* Show off c"Hello" literals