### PR TITLE
Use c"Foo" strings.

### DIFF
--- a/example-code/native/stdout/src/bin/5_puts.rs
+++ b/example-code/native/stdout/src/bin/5_puts.rs
@@ -5,7 +5,7 @@ extern "C" {
 }
 
 fn main() {
-    let message = std::ffi::CStr::from_bytes_with_nul("Hello, world!\0".as_bytes()).unwrap();
+    let message = c"Hello, world!";
     let result = unsafe { puts(message.as_ptr()) };
     if result < 0 {
         panic!("puts returned {result}");


### PR DESCRIPTION
Using c"Foo" strings is much nicer than calling the old CStr functions and unwrapping the result.