### PR TITLE
Bump ferrocene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Add Rust Targets
         run: |
           rustup target add thumbv7em-none-eabihf
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrocene/criticalup/releases/download/v1.0.1/criticalup-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrocene/criticalup/releases/download/v1.1.0/criticalup-installer.sh | sh
 
       - name: Find slug name
         run: |

--- a/example-code/qemu-aarch32v78r/criticalup.toml
+++ b/example-code/qemu-aarch32v78r/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "rolling-2024-06-12"
+release = "stable-24.08.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",

--- a/example-code/qemu-aarch64v8a/criticalup.toml
+++ b/example-code/qemu-aarch64v8a/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "rolling-2024-06-12"
+release = "stable-24.08.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",


### PR DESCRIPTION
Updates criticalup to 1.1.0 and ferrocene to 24.08 for the two examples.