### PR TITLE
Swap the lang string order for the code blocks

### DIFF
--- a/training-slides/src/board-support.md
+++ b/training-slides/src/board-support.md
@@ -28,7 +28,7 @@
 
 See `example-code/nrf52/bsp_demo`
 
-```rust [] ignore
+```rust ignore []
 #[entry]
 fn main() -> ! {
     let mut nrf52 = Board::take().unwrap();
@@ -48,7 +48,7 @@ the UART pins. The Board Support Crate did it all for us.
 
 ## Making a Board Support Crate
 
-```rust [] ignore
+```rust ignore []
 pub struct Board {
     /// The nRF52's pins which are not otherwise occupied on the nRF52840-DK
     pub pins: Pins,

--- a/training-slides/src/design-patterns.md
+++ b/training-slides/src/design-patterns.md
@@ -159,7 +159,7 @@ fn main() {
 - Use it to get the inner Type, say in `Option`.
 - Use it to your advantage to make variable immutable after it's served its purpose.
 
-```rust [] ignore
+```rust ignore []
 // Get the inner type from Option
 let array = [1, 2, 3, 4];
 let item = array.get(1);

--- a/training-slides/src/drop-panic-abort.md
+++ b/training-slides/src/drop-panic-abort.md
@@ -23,7 +23,7 @@ For this, the `Drop` trait can be implemented.
 
 ---
 
-```rust [] ignore
+```rust ignore []
 struct LevelDB {
     handle: *mut leveldb_database_t
 }
@@ -49,7 +49,7 @@ Implementing a `Drop`-bomb (a failing destructor) can make sure this error is ca
 
 Rust also has another error mechanism: `panic!`
 
-```rust [] should_panic
+```rust should_panic []
 fn main() {
     panicking_function();
 }

--- a/training-slides/src/embedded-hals.md
+++ b/training-slides/src/embedded-hals.md
@@ -26,7 +26,7 @@ trait GenericSerial {
 
 ## My Library
 
-```rust [] ignore
+```rust ignore []
 struct AtCommandParser<T> {
     uart: T,
     ...
@@ -42,7 +42,7 @@ Note how `AtCommandParser` *owns* the object which meets the `GenericSerial` tra
 
 ## My Application
 
-```rust [] ignore
+```rust ignore []
 let uart = stm32_hal::Uart::new(...);
 let at_parser = at_library::AtCommandParser::new(uart);
 while let Some(cmd) = at_parser.get_command().unwrap() {
@@ -52,7 +52,7 @@ while let Some(cmd) = at_parser.get_command().unwrap() {
 
 ## My Application (2)
 
-```rust [] ignore
+```rust ignore []
 let uart = nrf52_hal::Uart::new(...);
 let at_parser = at_library::AtCommandParser::new(uart);
 while let Some(cmd) = at_parser.get_command().unwrap() {

--- a/training-slides/src/error-handling.md
+++ b/training-slides/src/error-handling.md
@@ -205,7 +205,7 @@ enum Error {
 
 So, people created helper crates like [`thiserror`](https://crates.io/crates/thiserror)
 
-```rust [] ignore
+```rust ignore []
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/training-slides/src/ffi.md
+++ b/training-slides/src/ffi.md
@@ -257,7 +257,7 @@ only 16-bits in size.
 
 ## Calling this
 
-```rust [] ignore
+```rust ignore []
 use std::ffi::{c_char, c_uint};
 
 extern "C" {
@@ -302,7 +302,7 @@ pub struct FoobarHandle(*mut FoobarContext);
 
 `extern "C"` applies to function pointers given to extern functions too.
 
-```rust [] ignore
+```rust ignore []
 use std::ffi::c_void;
 
 pub type FooCallback = extern "C" fn(state: *mut c_void);

--- a/training-slides/src/heap.md
+++ b/training-slides/src/heap.md
@@ -234,7 +234,7 @@ fn main() {
 
 Why is this function less than ideal?
 
-```rust [] should_panic
+```rust should_panic []
 /// Replaces all the ` ` characters with `_`
 fn replace_spaces(input: &str) -> String {
     todo!()
@@ -254,7 +254,7 @@ Did the second call replace anything? Did you have to allocate a `String` and co
 
 Rust has the [`Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html) type to handle this.
 
-```rust [] should_panic
+```rust should_panic []
 /// Replaces all the ` ` characters with `_`
 fn replace_spaces(input: &str) -> std::borrow::Cow<str> {
     todo!()

--- a/training-slides/src/macros.md
+++ b/training-slides/src/macros.md
@@ -76,7 +76,7 @@ The actual macro is more complicated as it sets the `Vec` to have the correct ca
 
 ## Expanding `println!`
 
-```rust [] ignore
+```rust ignore []
 fn main() {
     // You write
     println!("Hello {}, aged {}", "Sam", 40);
@@ -123,7 +123,7 @@ This is a simplified example - the real output is slightly more complicated, and
 
 Work like the built-in Rust derives, once you've imported them:
 
-```rust [] ignore
+```rust ignore []
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
@@ -151,7 +151,7 @@ Rust can always work out whether you mean the trait or the macro, from the conte
 * Placed above a type, function, or field
 * Can have optional arguments
 
-```rust [] ignore
+```rust ignore []
 #[tokio::main(worker_threads = 2)]
 async fn main() {
     println!("Hello world");

--- a/training-slides/src/methods-traits.md
+++ b/training-slides/src/methods-traits.md
@@ -45,7 +45,7 @@ For motivation for something that takes `self`, imagine an embedded device with 
 
 * Other, fancier, *method receivers* [are available](https://doc.rust-lang.org/reference/items/associated-items.html)!
 
-```rust [] ignore
+```rust ignore []
 struct Square(f64);
 
 impl Square {
@@ -216,7 +216,7 @@ We walk the attendees through each of these examples. They are only listed in pa
 
 If a trait method uses `&mut self` and you really want it to work on some `&SomeType` reference, you can:
 
-```rust [] ignore
+```rust ignore []
 impl SomeTrait for &SomeType {
     // ...
 }

--- a/training-slides/src/pac-svd2rust.md
+++ b/training-slides/src/pac-svd2rust.md
@@ -80,7 +80,7 @@ uart0_reg_t* const p_uart = (uart0_reg_t*) 0x40002000;
 
 ## Structures in Rust
 
-```rust [] ignore
+```rust ignore []
 #[repr(C)]
 pub struct Uart0 {
     pub tasks_startrx: VolatileCell<u32>, // @ 0x000
@@ -222,7 +222,7 @@ graph TB
 
 ## Using a PAC
 
-```rust [] ignore
+```rust ignore []
 let p = nrf52840_pac::Peripherals::take().unwrap();
 // Reading the 'baudrate' field
 let contents = p.UARTE1.baudrate.read();
@@ -258,7 +258,7 @@ function. We see this used [all
 
 What are the three steps here?
 
-```rust [] ignore
+```rust ignore []
 p.UARTE1.inten.modify(|_r, w| {
     w.cts().enabled();
     w.ncts().enabled();

--- a/training-slides/src/safety-performance-productivity.md
+++ b/training-slides/src/safety-performance-productivity.md
@@ -29,7 +29,7 @@ memory.
 
 ## Iter Example
 
-```rust [] ignore
+```rust ignore []
 /// Adds 0x00 padding for every 0xCC found
 fn process(data: &mut Vec<u8>) {
     for item in data.iter_mut() {
@@ -197,7 +197,7 @@ sum = 24999999500000002500000000000000
 
 ## Let's use all our CPU cores...
 
-```rust [] ignore
+```rust ignore []
 // Import the rayon library
 use rayon::prelude::*;
 

--- a/training-slides/src/serde.md
+++ b/training-slides/src/serde.md
@@ -8,7 +8,7 @@
 
 To make a Rust structure (de)serializable:
 
-```rust [] ignore
+```rust ignore []
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Move {
     id: usize,
@@ -37,7 +37,7 @@ Did you enjoy that acronym salad?
 
 To JSON:
 
-```rust [] ignore
+```rust ignore []
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,7 +60,7 @@ fn main() {
 
 From JSON:
 
-```rust [] ignore
+```rust ignore []
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -81,7 +81,7 @@ fn main() {
 
 ## Transcode
 
-```rust [] ignore
+```rust ignore []
 use serde::{Serialize, Deserialize};
 use serde_transcode::transcode;
 
@@ -111,7 +111,7 @@ fn main() {
 
 `serde` has a large number of attributes you can utilize:
 
-```rust [] ignore
+```rust ignore []
 #[serde(deny_unknown_fields)] // Be extra strict
 struct Move {
     #[serde(default)] // Call usize::default()

--- a/training-slides/src/type-state.md
+++ b/training-slides/src/type-state.md
@@ -18,7 +18,7 @@ A GPIO pin on a microcontroller. It typically has:
 
 Is this program correct?
 
-```rust [] ignore
+```rust ignore []
 let p = GpioPin::new(7);
 if p.is_low() {
     println!("Button is pressed");
@@ -41,7 +41,7 @@ types.
 
 We've got a type system with traits and a powerful static analysis engine...
 
-```rust [] ignore
+```rust ignore []
 let p = OutputPin::new(7);
 if p.is_low() {
     println!("Button is pressed");
@@ -60,7 +60,7 @@ if p.is_low() {
 
 With a method that takes ownership:
 
-```rust [] ignore
+```rust ignore []
 impl OutputPin {
     fn into_input(self) -> InputPin {
         poke_hardware_registers();
@@ -147,7 +147,7 @@ impl Pin<Input> {
 
 Who can `impl PinMode for Type`? Turns out anyone can...
 
-```rust [] ignore
+```rust ignore []
 use my_driver_crate::{Pin, PinMode};
 
 struct OnFire {}

--- a/training-slides/src/writing-drivers.md
+++ b/training-slides/src/writing-drivers.md
@@ -8,7 +8,7 @@
 
 ## Typical driver interface
 
-```rust [] ignore
+```rust ignore []
 let p = pac::Peripherals.take().unwrap();
 let mut uarte0 = hal::uarte::Uarte::new(
     // Our singleton representing exclusive access to
@@ -46,7 +46,7 @@ uarte0.write_all(b"Hey, I'm using a UART!").unwrap();
 
 ## Handling GPIO pins with code
 
-```rust [] ignore
+```rust ignore []
 // Get the singletons
 let p = pac::Peripherals.take().unwrap();
 // Make a driver for GPIO port P0
@@ -69,7 +69,7 @@ restrictive!
 
 ## Giving the pins to the driver
 
-```rust [] ignore
+```rust ignore []
 // 'degrade()' converts a P0_08 type into a generic Pin type.
 let pins =  hal::uarte::Pins {
     rxd: pins.p0_08.degrade().into_floating_input(),


### PR DESCRIPTION
As of Rust 1.80, rustdoc stops parsing the langstring when it sees `[]`. So move `[]` to the end of every langstring.