### PR TITLE
Link tools mentioned

### DIFF
--- a/training-slides/src/rust-build-time.md
+++ b/training-slides/src/rust-build-time.md
@@ -109,5 +109,5 @@ To clarify
 
 ## Tools
 
-* `cargo-chef` to speed up your docker builds
-* `sccache` for caching intermediary build artifacts across multiple projects and developers
+* [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef) to speed up your docker builds
+* [`sccache`](https://github.com/mozilla/sccache) for caching intermediary build artifacts across multiple projects and developers


### PR DESCRIPTION
If you'd rather not link `code` I can rework. Afaik there are a few other places throughout the slides that don't have explicit links, I'm happy to find and fix if that's useful.