### PR TITLE
Fix QEMU demo start addresses.

### DIFF
--- a/example-code/qemu-aarch32v78r/linker.ld
+++ b/example-code/qemu-aarch32v78r/linker.ld
@@ -1,7 +1,11 @@
-/* RAM starts at 0x40000000 but if we ask to load the kernel there, QEMU will not load a DTB */
+/*
+RAM starts at 0x20000000.
+
+See https://github.com/qemu/qemu/blob/master/hw/arm/mpsr3.c
+*/
 
 MEMORY {
-    RAM : ORIGIN = 0x40100000, LENGTH = 128M
+    RAM : ORIGIN = 0x20000000, LENGTH = 128M
 }
 
 ENTRY(_start)

--- a/example-code/qemu-aarch64v8a/linker.ld
+++ b/example-code/qemu-aarch64v8a/linker.ld
@@ -1,7 +1,11 @@
-/* RAM starts at 0x40000000 but if we ask to load the kernel there, QEMU will not load a DTB */
+/*
+RAM starts at 0x40000000.
+
+See https://github.com/qemu/qemu/blob/master/hw/arm/virt.c
+*/
 
 MEMORY {
-    RAM : ORIGIN = 0x40100000, LENGTH = 128M
+    RAM : ORIGIN = 0x40000000, LENGTH = 128M
 }
 
 ENTRY(_start)


### PR DESCRIPTION
The 32-bit Arm QEMU has 3GB of DDR so our address worked, but let's load at the start of RAM instead.

Also removed the DTB adjustment because that doesn't seem to be necessary.