### PR TITLE
Adds a Visual Studio FFI project to use-rust-in-c.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,3 +131,20 @@ jobs:
           if-no-files-found: error
           path: |
             ./rust-training-*/
+
+  build-windows-examples:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Rust
+        run: |
+          rustup update stable
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+      - name: Build FFI Example
+        run: |
+          cd example-code\native\ffi\use-rust-in-c\windows-example
+          msbuild.exe windows-example.sln /p:Configuration=Debug
+          .\x64\Debug\windows-example.exe
+          msbuild.exe windows-example.sln /p:Configuration=Release
+          .\x64\Release\windows-example.exe

--- a/example-code/native/ffi/use-rust-in-c/.gitignore
+++ b/example-code/native/ffi/use-rust-in-c/.gitignore
@@ -1,3 +1,2 @@
 example
-
 example.dSYM

--- a/example-code/native/ffi/use-rust-in-c/windows-example/.gitignore
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/.gitignore
@@ -1,0 +1,5 @@
+windows-example/
+x64/
+.vs/
+*.vcxproj.user
+

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.cpp
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.cpp
@@ -1,0 +1,37 @@
+// windows-example.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include <iostream>
+
+extern "C" {
+	/// Designed to have the exact same shape as the Rust version
+	typedef struct magic_adder_t {
+		uint32_t amount;
+	} magic_adder_t;
+
+	/// Wraps MagicAdder::new
+	extern magic_adder_t magicadder_new(uint32_t amount);
+
+	/// Wraps MagicAdder::process_value
+	extern uint32_t magicadder_process_value(magic_adder_t* self, uint32_t value);
+
+	/// Heap allocate a new magic_adder_t
+	magic_adder_t* magicadder_allocate(uint32_t amount);
+
+	/// Destroy a magic_adder_t that was created with `magicadder_allocate`
+	void magicadder_free(magic_adder_t* p_adder);
+
+}
+
+int main()
+{
+	magic_adder_t ma = magicadder_new(5);
+	printf("5 + 6 = %u\n", magicadder_process_value(&ma, 6));
+
+	magic_adder_t* p_ma = magicadder_allocate(10);
+	printf("10 + 6 = %u\n", magicadder_process_value(p_ma, 6));
+	magicadder_free(p_ma);
+	magicadder_free(NULL); // won't explode
+	return 0;
+}
+

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.sln
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35222.181
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "windows-example", "windows-example.vcxproj", "{E78CB23E-7475-4424-B787-B262533D0805}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E78CB23E-7475-4424-B787-B262533D0805}.Debug|x64.ActiveCfg = Debug|x64
+		{E78CB23E-7475-4424-B787-B262533D0805}.Debug|x64.Build.0 = Debug|x64
+		{E78CB23E-7475-4424-B787-B262533D0805}.Debug|x86.ActiveCfg = Debug|Win32
+		{E78CB23E-7475-4424-B787-B262533D0805}.Debug|x86.Build.0 = Debug|Win32
+		{E78CB23E-7475-4424-B787-B262533D0805}.Release|x64.ActiveCfg = Release|x64
+		{E78CB23E-7475-4424-B787-B262533D0805}.Release|x64.Build.0 = Release|x64
+		{E78CB23E-7475-4424-B787-B262533D0805}.Release|x86.ActiveCfg = Release|Win32
+		{E78CB23E-7475-4424-B787-B262533D0805}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6C228E2F-46CA-47CC-855B-8E58D76A0045}
+	EndGlobalSection
+EndGlobal

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
@@ -108,11 +108,11 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(ProjectPath)\..\..\target\debug\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)\..\target\debug\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>cd $(ProjectPath)\..
+      <Command>cd $(ProjectDir)\..
 cargo build
 </Command>
     </PreBuildEvent>
@@ -134,7 +134,7 @@ cargo build
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(ProjectPath)\..\..\target\release\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)\..\target\release\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
     <PreBuildEvent>

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{e78cb23e-7475-4424-b787-b262533d0805}</ProjectGuid>
+    <RootNamespace>windowsexample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(ProjectPath)\..\..\target\debug\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+    </Link>
+    <PreBuildEvent>
+      <Command>cd $(ProjectPath)\..
+cargo build
+</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build Rust library (debug)</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(ProjectPath)\..\..\target\release\ffi_use_rust_in_c.lib;kernel32.lib;advapi32.lib;ntdll.lib;userenv.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+    </Link>
+    <PreBuildEvent>
+      <Command>cd $(ProjectPath)\..
+cargo build --release
+</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Build Rust library (release)</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="windows-example.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj.filters
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="windows-example.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Setting up the right linker arguments turned out to be quite tricky.

`rustc --crate-type staticlib --print native-static-libs src/lib.rs` is what you need. See https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information.

