### PR TITLE
Draft: remove mermaid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.4.36,mdbook-mermaid@0.13.0
+          tool: mdbook@0.4.42,mdbook-graphviz@0.2.1
 
       - name: Add mdslides
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 html
 mdbook
-mdbook-mermaid
+mdbook-graphviz
 mdslides

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ This slide deck is an [`mdbook`](https://crates.io/crates/mdbook) that is also c
 To build as a book, run `mdbook` in the usual fashion:
 
 ```console
+$ apt install graphviz
 $ cargo install mdbook
-$ cargo install mdbook-mermaid
+$ cargo install mdbook-graphviz
 $ cd ./training-slides
 $ mdbook build
 2023-05-03 13:24:46 [INFO] (mdbook::book): Book building has started
@@ -55,6 +56,7 @@ mdbook test
 To convert the book to slides, run `mdslides` like this:
 
 ```console
+$ apt install graphviz
 $ cargo install mdslides
 $ cd ./training-slides
 $ mdslides --template ./template.html --output-dir ./slides --mdbook-path . --index-template ./index-template.html 

--- a/build.sh
+++ b/build.sh
@@ -12,13 +12,14 @@ set -euo pipefail
 # We only support macOS (the x86 binaries work OK on Apple Silicon), or x86-64 Linux
 if [ $(uname) == "Darwin" ]; then
     ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-apple-darwin.tar.gz | tar -xvzf -
-    ./mdbook-mermaid --version || curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-apple-darwin.tar.gz | tar -xvzf -
+    mdbook-graphviz --version || cargo install mdbook-graphviz
     ./mdslides --version || ( curl -sSL https://github.com/ferrous-systems/mdslides/releases/download/v0.4.0/mdslides-x86_64-apple-darwin.tar.xz | tar -xvJf - \
         && mv ./mdslides-*/mdslides . \
         && rm -rf ./mdslides-*/ )
 else
     ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
-    ./mdbook-mermaid --version || curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    ./mdbook-graphviz --version || ( curl -sSL https://github.com/dylanowen/mdbook-graphviz/releases/download/v0.2.1/mdbook-graphviz_v0.2.1_x86_64-unknown-linux-musl.zip | tar -xvzf - \
+        && chmod a+x ./mdbook-graphviz )
     ./mdslides --version || ( curl -sSL https://github.com/ferrous-systems/mdslides/releases/download/v0.4.0/mdslides-x86_64-unknown-linux-gnu.tar.xz | tar -xvJf - \
         && mv ./mdslides-*/mdslides . \
         && rm -rf ./mdslides-*/ )
@@ -37,7 +38,7 @@ cp ./_redirects "${OUTPUT_DIR}/_redirects"
 function build_and_store {
     mkdir -p "${OUTPUT_DIR}/$1"
     # Build the book first, because mdbook will create any empty sections
-    # The PATH override lets it find our local copy of mdbook-mermaid
+    # The PATH override lets it find our local copy of mdbook-graphviz
     PATH=$PATH:. ./mdbook build -d "${OUTPUT_DIR}/$1/book" ./training-slides
     # Then build the slides
     RUST_LOG=info ./mdslides --template ./training-slides/template.html \

--- a/training-slides/book.toml
+++ b/training-slides/book.toml
@@ -5,8 +5,8 @@ multilingual = false
 src = "src"
 title = "Rust Training Slides by Ferrous Systems"
 
-[preprocessor.mermaid]
-command = "mdbook-mermaid"
+[preprocessor.graphviz]
+command = "mdbook-graphviz"
 
 [output.html.playground]
 copyable = true          # include the copy button for copying code snippets

--- a/training-slides/src/advanced-strings.md
+++ b/training-slides/src/advanced-strings.md
@@ -12,12 +12,22 @@ Most common are `String` and `&str`.
 -   The bytes it points at exist on the *heap*
 -   Does not implement `Copy`, but implements `Clone`
 
-```mermaid
-flowchart LR
-    data("[0x31, 0x32, 0x33, 0x00, 0x00]")
-    string["String { ptr, cap: 5, len: 3 }"]
-    string --> data
-    style data fill:#ccf
+<br>
+<br>
+
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "string:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    _inner [label="<f0> 0x48 | 0x65 | 0x6c | 0x6c | 0x6f | 0x21 | 0xFF | 0xFF", color=blue, fillcolor=lightgreen, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    string [label="<p0> ptr | len = 6 | cap = 8", color=blue, fillcolor=lightblue, style=filled];
+    string:p0 -> _inner:f0;
+
+    { rank=same; "string:"; string }
+}
 ```
 
 ## `&str`
@@ -26,28 +36,20 @@ flowchart LR
 -   Usually only seen as a borrowed value
 -   The bytes it points at may be anywhere: heap, stack, or in read-only memory
 
-```mermaid
-flowchart LR
-    data1("[0x31, 0x32, 0x33, 0x00, 0x00]")
-    string["String { ptr, cap: 5, len: 3 }"]
-    string --> data1
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "str:" [color=white];
 
-    data2("[0x34, 0x35, 0x36, 0x37]")
-    str1["&str { ptr, len: 4 }"]
-    str1 -.-> data2
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    bytes [label="<f0> 0xC2 | 0xA3 | 0x39 | 0x39 | 0x21", color=blue, fillcolor=lightblue, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    str [label="<p0> ptr | len = 5", color=blue, fillcolor=lightblue, style=filled];
+    str:p0 -> bytes:f0;
 
-    str2["&str { ptr, len: 3 }"]
-    str2 -.-> data1
-
-    style data1 fill:#ccf
-    style data2 fill:#cfc
+    { rank=same; "str:"; str }
+}
 ```
-
-Note:
-
-The dark blue block of data is heap allocated.
-
-The green block of data is a string literal in read-only memory (i.e. in the `.rodata` section).
 
 ## Creation
 
@@ -102,6 +104,12 @@ These types represent *platform native* strings. This is necessary because Unix 
 -   Rust strings are always valid UTF-8, and may contain `NUL` bytes.
 
 `OsString` and `OsStr` bridge this gap and allow for conversion to and from `String` and `str`.
+
+Note:
+
+In particular, UNIX file paths are not required to be valid UTF-8 and you might encounter such paths when looking at someone's disk.
+
+Windows file paths are also not required to be valid UTF-16 (i.e. might contain invalid surrogate pairs) and you might encounter such paths when looking at someone's disk.
 
 ## `CString` & `CStr`
 

--- a/training-slides/src/collections.md
+++ b/training-slides/src/collections.md
@@ -2,7 +2,7 @@
 
 ## Using Arrays
 
-In Rust, arrays (`[T; N]`) have a fixed size.
+Arrays (`[T; N]`) have a fixed size.
 
 ```rust []
 fn main() {
@@ -13,9 +13,16 @@ fn main() {
 
 <br>
 
-```mermaid
-flowchart LR
-    array("[1, 2, 3, 4, 5]")
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "array:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=4.75, fixedsize=true];
+    array [label="1 | 2 | 3 | 4 | 5", color=blue, fillcolor=lightblue, style=filled];
+
+    { rank=same; "array:"; array }
+}
 ```
 
 ## Building the array at runtime.
@@ -34,16 +41,21 @@ fn main() {
 
 <br>
 
-```mermaid
-flowchart LR
-    array("[0, 1, 2, 3, 4, 0, 0, 0, 0, 0]")
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "array:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=4.75, fixedsize=true];
+    array [label="0 | 1 | 2 | 3 | 4 | 0 | 0 | 0 | 0 | 0", color=blue, fillcolor=lightblue, style=filled];
+
+    { rank=same; "array:"; array }
+}
 ```
 
 ## Slices
 
-A view into *some other data*, plus a value to indicate *how many items*.
-
-Written as `&[T]` (or `&mut [T]`).
+A view into *some other data*. Written as `&[T]` (or `&mut [T]`).
 
 ```rust [1-8|6]
 fn main() {
@@ -58,11 +70,20 @@ fn main() {
 
 <br>
 
-```mermaid
-flowchart LR
-    array("[0, 1, 2, 3, 4, 0, 0, 0, 0, 0]")
-    data["&[u8] { ptr, len: 5 }"]
-    data -.-> array
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "data:" -> "array:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    array [label="<f0> 0 | 1 | 2 | 3 | 4 | 0 | 0 | 0 | 0 | 0", color=blue, fillcolor=lightblue, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    data [label="<p0> ptr | len = 5", color=blue, fillcolor=lightblue, style=filled];
+    data:p0 -> array:f0;
+
+    { rank=same; "data:"; data }
+    { rank=same; "array:"; array }
+}
 ```
 
 Note:
@@ -70,7 +91,7 @@ Slices are *unsized* types and can only be access via a reference. This referenc
 
 ## Vectors
 
-If you don't how how much space you will need, a `Vec` is a growable, heap-allocated, array-like type, that you can index and also treat as a slice.
+`Vec` is a growable, heap-allocated, array-like type.
 
 ```rust []
 fn process_data(input: &[u32]) {
@@ -86,17 +107,24 @@ fn main() { process_data(&[1, 2, 3]); }
 
 <br>
 
-```mermaid
-flowchart LR
-    data("[2, 4, 6, 0]")
-    vector["Vec { ptr, cap: 4, len: 3 }"]
-    vector --> data
-    style data fill:#ccf
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "vector:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    _inner [label="<f0> 2 | 4 | 6 | 0", color=blue, fillcolor=lightgreen, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    vector [label="<p0> ptr | len = 3 | cap = 4", color=blue, fillcolor=lightblue, style=filled];
+    vector:p0 -> _inner:f0;
+
+    { rank=same; "vector:"; vector }
+}
 ```
 
 Note:
 
-The dark blue block of data is heap allocated.
+The green block of data is heap allocated.
 
 ## There's a macro short-cut too...
 
@@ -139,11 +167,20 @@ fn main() {
 
 <br>
 
-```mermaid
-flowchart LR
-    data("[0xC2, 0xA3, 0x39, 0x39, 0x21]")
-    s["&str { ptr, len: 5 }"]
-    s -.-> data
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "s:" -> "bytes:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    bytes [label="<f0> 0xC2 | 0xA3 | 0x39 | 0x39 | 0x21", color=blue, fillcolor=lightblue, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    s [label="<p0> ptr | len = 5", color=blue, fillcolor=lightblue, style=filled];
+    s:p0 -> bytes:f0;
+
+    { rank=same; "s:"; s }
+    { rank=same; "bytes:"; bytes }
+}
 ```
 
 Note:
@@ -164,18 +201,19 @@ fn main() {
 
 <br>
 
-```mermaid
-flowchart LR
-    data1("[0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21")
-    str1["&str { ptr, len: 6 }"]
-    str1 -.-> data1
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "s:" [color=white];
 
-    data2("[0x73, 0x20, 0x3d, 0x20")
-    str2["&str { ptr, len: 4 }"]
-    str2 -.-> data2
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    bytes [label="<f0> 0x48 | 0x65 | 0x6c | 0x6c | 0x6f | 0x21", color=blue, fillcolor=lightgray, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    s [label="<p0> ptr | len = 5", color=blue, fillcolor=lightblue, style=filled];
+    s:p0 -> bytes:f0;
 
-    style data1 fill:#cfc
-    style data2 fill:#cfc
+    { rank=same; "s:"; s }
+}
 ```
 
 Note:
@@ -184,7 +222,9 @@ The lifetime annotation of `'static` just means the string slice lives forever
 and never gets destroyed. We wrote out the type in full so you can see it - you
 can emit it on variable declarations.
 
-The second green object is the literal we gave to println - `s = `
+There's a second string literal in this program. Can you spot it?
+
+(It's the format string in the call to `println!`)
 
 ## Strings ([docs](https://doc.rust-lang.org/std/string/struct.String.html))
 
@@ -193,17 +233,32 @@ The second green object is the literal we gave to println - `s = `
 * You cannot access characters by index (only bytes)
   * But you never really want to anyway
 
-```mermaid
-flowchart LR
-    data("[0xc2, 0xa3, 0x31, 0x32, 0x00]")
-    string["String { ptr, cap: 5, len: 4 }"]
-    string --> data
-    style data fill:#ccf
+```rust
+fn main() {
+    let string = String::from("Hello!");
+}
+```
+
+<br>
+
+```dot process
+digraph {
+    node [shape=plaintext, fontcolor=black, fontsize=18];
+    "string:" [color=white];
+
+    node [shape=record, fontcolor=black, fontsize=14, width=3];
+    _inner [label="<f0> 0x48 | 0x65 | 0x6c | 0x6c | 0x6f | 0x21", color=blue, fillcolor=lightgreen, style=filled];
+    node [shape=record, fontcolor=black, fontsize=14, width=2];
+    string [label="<p0> ptr | len = 6 | cap = 6", color=blue, fillcolor=lightblue, style=filled];
+    string:p0 -> _inner:f0;
+
+    { rank=same; "string:"; string }
+}
 ```
 
 Note:
 
-The dark blue block of data is heap allocated.
+The green block of data is heap allocated.
 
 ## Making a String
 
@@ -378,7 +433,7 @@ We also have [HashSet](https://doc.rust-lang.org/std/collections/struct.HashSet.
 
 Just sets the `V` type parameter to `()`!
 
-## A Summary
+---
 
 | Type         | Owns | Grow |  Index  | Slice | Cheap Insert |
 | :----------- | :--: | :--: | :-----: | :---: | :----------: |

--- a/training-slides/src/installation.md
+++ b/training-slides/src/installation.md
@@ -35,15 +35,18 @@ History](https://rust-lang.github.io/rustup-components-history/)
 
 ## Contents of the toolchain
 
-```mermaid
-graph TD;
-    C(cargo) --> R(rustc);
-    C --> D(rustdoc);
-    C --> F(rustfmt);
-    C --> L(clippy);
-    R --> S(libstd);
-    R --> O(libcore);
-    S --> O;
+```dot process
+digraph {
+    node [shape=record, fontcolor=black, fontsize=14, width=3, fillcolor=lightgreen, style=filled];
+    cargo -> rustc;
+    cargo -> rustdoc;
+    cargo -> rustfmt;
+    cargo -> clippy;
+    node [shape=record, fontcolor=black, fontsize=14, width=3, fillcolor=lightblue, style=filled];
+    rustc -> libstd;
+    rustc -> libcore;
+    libstd -> libcore;
+}
 ```
 
 ## Hello, world! with Cargo

--- a/training-slides/src/introduction.md
+++ b/training-slides/src/introduction.md
@@ -10,29 +10,37 @@ We have a standard grouping of *lessons* into *modules*, but this can be customi
 
 Most of our modules are available now (shown in blue), but some are still in development and will be available in the future (shown in grey).
 
-```mermaid
----
-title: Ferrous Systems' Rust Training Modules
-config:
-  theme: base
-  themeVariables:
-    primaryColor: "#cdf"
----
-graph TD;
-    Fundamentals(Rust Fundamentals)-->Applied(Applied Rust);
-    Applied-->Advanced(Advanced Rust);
-    Applied-->NoStd(No-Std Rust);
-    NoStd-->Ferrocene(Using Ferrocene);
-    Applied-->BareMetal(Bare-Metal Rust);
-    Applied-->Async(Async Rust);
-    Applied-->Wasm(Rust and WebAssembly);
-    BareMetal-->Embassy(Using Embassy);
-    Async-->Embassy;
-    WhyRust(Why Rust?);
-    WhyFerrocene(Why Ferrocene?);
+## Ferrous Systems' Rust Training Modules
 
-    classDef grey fill:#eee,stroke:#ccc;
-    class Async,Embassy grey
+```dot process
+digraph {
+    node [shape=record, width=1.5, fillcolor=lightgreen, style=filled];
+    Advanced [label="Advanced Rust"];
+    Applied [label="Applied Rust"];
+    BareMetal [label="Bare-Metal Rust"];
+    Ferrocene [label="Using Ferrocene"];
+    Fundamentals [label="Rust Fundamentals"];
+    NoStd [label="No-Std Rust"];
+    Wasm [label="Rust and WebAssembly"];
+
+    node [shape=record, fillcolor=lightblue, style=filled];
+    WhyFerrocene [label="Why Ferrocene?"];
+    WhyRust [label="Why Rust?"];
+
+    node [shape=record, fillcolor=lightgray, style=filled];
+    Async [label="Async Rust"];
+    Embassy [label="Using Embassy"];
+
+    Fundamentals -> Applied;
+    Applied -> Advanced;
+    Applied -> NoStd;
+    NoStd -> Ferrocene;
+    Applied -> BareMetal;
+    Applied -> Async;
+    Applied -> Wasm;
+    BareMetal -> Embassy;
+    Async -> Embassy;
+}
 ```
 
 * **Why Rust?**: A (stand-alone) half-day tour of Rust for decision-makers, technical leads and managers.

--- a/training-slides/src/iterators.md
+++ b/training-slides/src/iterators.md
@@ -100,31 +100,18 @@ fn main() {
 
 ## Three kinds of Iterator
 
-```mermaid
-classDiagram
-    note for Vec "Our std::vec::Vec"
-    class Vec {
-        start: *mut T
-        size: usize
-        used: usize
-    }
-    note for Iter "If you call .iter()"
-    class Iter {
-        parent: &[T]
-        +next(&mut self) Option<&T>
-    }
-    note for IterMut "If you call .iter_mut()"
-    class IterMut {
-        parent: &mut [T]
-        +next(&mut self) Option<&mut T>
-    }
-    note for IntoIter "If you call .into_iter()"
-    class IntoIter {
-        start: *mut T
-        size: usize
-        used: usize
-        +next(&mut self) Option< T >
-    }
+```dot process
+digraph {
+    node [shape=record];
+    Vec[label="{struct Vec|start: *mut T\nlen: usize\ncap: usize|<i>fn iter(&self) -\> VecIter|<im>fn iter_mut(&mut self) -\> VecIterMut|<ii> fn into_iter(self) -\> VecIter}"];
+    VecIntoIter[label="{struct VecIntoIter|start: *mut T\nlen: usize\ncap: usize|Item=T}"];
+    VecIterMut[label="{struct VecIterMut|parent: &mut [T]|Item=&mut T}"];
+    VecIter[label="{struct VecIter|parent: &[T]|Item=&T}"];
+
+    Vec:ii -> VecIntoIter;
+    Vec:im -> VecIterMut;
+    Vec:i -> VecIter;
+}
 ```
 
 ## Three kinds of Iterator

--- a/training-slides/src/pac-svd2rust.md
+++ b/training-slides/src/pac-svd2rust.md
@@ -106,8 +106,6 @@ unsound.
 
 ## Other approaches
 
-Some developers prefer to generate a pointer for each peripheral register:
-
 ```rust []
 pub struct Uart { base: *mut u32 } // now has no fields
 
@@ -174,9 +172,21 @@ registers and fields on an MCU.
 
 We can use `svd2rust` to turn this into a Peripheral Access Crate.
 
-```mermaid
-graph LR
-    svd[(SVD XML)] --> svd2rust[<tt>svd2rust</tt>] --> rust[(Rust Source)]
+<br>
+
+```dot process
+
+digraph {
+    rankdir=LR;
+    node [shape=ellipse, width=1.5, fillcolor=lightgreen, style=filled];
+    svd [label="SVD XML"];
+    rust [label="Rust Source"];
+    node [shape=record, width=1.5, fillcolor=lightblue, style=filled];
+    svd2rust [label="svd2rust"];
+
+    svd -> svd2rust;
+    svd2rust -> rust;
+}
 ```
 
 Note:
@@ -191,14 +201,26 @@ fix known bugs in the SVD files.
 
 ## The `svd2rust` generated API
 
-```mermaid
-graph TB
-    Peripherals --> uarte1[.UARTE1: <b>UARTE1&nbsp;</b>]
-    uarte1 --> uart1_baudrate[.baudrate: <b>BAUDRATE&nbsp;</b>]
-    uarte1 --> uart1_inten[.inten: <b>INTEN&nbsp;</b>]
-    Peripherals --> uarte2[.UARTE2: <b>UARTE2&nbsp;</b>]
-    uarte2 --> uart2_baudrate[.baudrate: <b>BAUDRATE&nbsp;</b>]
-    uarte2 --> uart2_inten[.inten: <b>INTEN&nbsp;</b>]
+```dot process
+
+digraph {
+    node [shape=record, width=1.5, fillcolor=lightblue, style=filled];
+    Peripherals;
+    uarte1 [label=".UARTE1: UARTE1"];
+    uarte1_baudrate [label=".baudrate: BAUDATE"];
+    uarte1_inten [label=".inten: INTEN"];
+    uarte2 [label=".UARTE2: UARTE2"];
+    uarte2_baudrate [label=".baudrate: BAUDATE"];
+    uarte2_inten [label=".inten: INTEN"];
+
+    Peripherals -> uarte1;
+    uarte1 -> uarte1_baudrate;
+    uarte1 -> uarte1_inten;
+
+    Peripherals -> uarte2;
+    uarte2 -> uarte2_baudrate;
+    uarte2 -> uarte2_inten;
+}
 ```
 
 ---

--- a/training-slides/src/rust-bare-metal.md
+++ b/training-slides/src/rust-bare-metal.md
@@ -26,52 +26,38 @@ To support these elements, we (usually) have these layers.
 
 ---
 
-```mermaid
-graph TB
-    app(Application<br/><tt>my_application</tt>)
-    bsc[Board Support<br/><tt>nrf52840_dk</tt>]
-    hal[MCU HAL Implementation<br/><tt>nrf52480_hal</tt>]
-    lcd_driver[SPI LCD Driver<br/><tt>ssd1306</tt>]
-    hal_traits[[HAL Traits<br/><tt>embedded_hal</tt>]]
-    pac[MCU PAC<br/><tt>nrf52840-pac</tt>]
-    rt[Core Runtime<br/><tt>cortex_m_rt</tt>]
-    cp[Core Peripherals<br/><tt>cortex_m</tt>]
+```dot process
+digraph {
+    node [shape=oval, width=1.5, fillcolor=khaki1, style=filled];
+    app [label="Application\n(my_application)"]
 
-    subgraph Key
-        note1[Embedded Working Group]
-        note2[nrf-rs]
-        note3[You]
-        note4[Others]
-    end
+    node [shape=record, width=1.5, fillcolor=lightblue, style=filled];
+    bsc [label="Board Support\n(nrf52840_dk)"]
+    hal [label="MCU HAL Implementation\n(nrf52480_hal)"]
+    pac [label="MCU PAC\n(nrf52840-pac)"]
 
-    direction TB
-    app --> bsc
-    app & bsc --> hal
-    app --> lcd_driver
-    app & lcd_driver --> hal_traits
-    hal -- Implements --o hal_traits
-    app & hal --> pac
-    app & pac --> rt
-    app & pac & rt --> cp
+    node [shape=record, width=1.5, fillcolor=orange, style=filled];
+    lcd_driver [label="SPI LCD Driver\n(ssd1306)"]
 
-    class app binary;
-    class bsc library;
-    class lcd_driver library;
-    class hal mcu_library;
-    class pac mcu_library;
-    class hal_traits ewg_library;
-    class rt ewg_library;
-    class cp ewg_library;
+    node [shape=folder, width=1.5, fillcolor=lightgreen, style=filled];
+    hal_traits [label="HAL Traits\n(embedded_hal)"]
 
-    class note1 ewg_library;
-    class note2 mcu_library;
-    class note3 binary;
-    class note4 library;
+    node [shape=record, width=1.5, fillcolor=lightgreen, style=filled];
+    rt [label="Core Runtime\n(cortex_m_rt)"]
+    cp [label="Core Peripherals\n(cortex_m)"]
 
-    classDef binary fill:#fb8,stroke:#333,stroke-width:4px;
-    classDef library fill:#cf9,stroke:#333,stroke-width:2px;
-    classDef ewg_library fill:#f9c,stroke:#333,stroke-width:2px;
-    classDef mcu_library fill:#9cf,stroke:#333,stroke-width:2px;
+    app -> bsc;
+    bsc -> hal;
+    bsc -> hal_traits;
+    app -> lcd_driver;
+    lcd_driver -> hal_traits;
+    hal -> hal_traits [label="implements", style="dashed"]
+    hal -> pac;
+    app -> rt;
+    pac -> rt;
+    pac -> cp;
+    rt -> cp;
+}
 ```
 
 ## Don't worry

--- a/training-slides/template.html
+++ b/training-slides/template.html
@@ -96,8 +96,6 @@ $CONTENT
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/markdown/markdown.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/highlight/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
-    <!-- Stick with mermaid 9.x as 10.x uses ESM -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.4.0/mermaid.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.4.min.js" crossorigin="anonymous"></script>
     <script>
         const buttons = '<p><button class="open-in-playground">RUN</button></p>\n';
@@ -306,32 +304,6 @@ $CONTENT
                     // Center the mermaid diagrams.
                     el.style.cssText += 'text-align: center';
                 });
-
-                mermaid.initialize({
-                    startOnLoad: false,
-                    themeCSS: '.label { font-size: 28px; }'
-                });
-
-                let doMermaidStuff = function doMermaidStuff(event) {
-
-                    let mermaidDivs = event.currentSlide.querySelectorAll('.mermaid:not(.done)');
-                    let indices = Reveal.getIndices();
-                    let pageno = `${indices.h}-${indices.v}`
-
-                    mermaidDivs.forEach(function (mermaidDiv, i) {
-
-                        let insertSvg = function (svgCode, bindFunctions) {
-                            mermaidDiv.innerHTML = svgCode;
-                            mermaidDiv.classList.add('done');
-                        };
-                        let graphDefinition = mermaidDiv.textContent;
-                        mermaid.mermaidAPI.render(`mermaid${pageno}-${i}`, graphDefinition, insertSvg);
-                    });
-                    Reveal.layout();
-                };
-
-                Reveal.on('ready', event => doMermaidStuff(event));
-                Reveal.on('slidechanged', event => doMermaidStuff(event));
             });
         });
     </script>

--- a/training-slides/template.html
+++ b/training-slides/template.html
@@ -71,6 +71,11 @@
             grid-template-columns: repeat(2, minmax(0, 1fr));
             gap: 1rem;
         }
+
+        .scrollable-slide {
+            height: 720px;
+            overflow-y: auto !important;
+        }
     </style>
 </head>
 
@@ -304,6 +309,25 @@ $CONTENT
                     // Center the mermaid diagrams.
                     el.style.cssText += 'text-align: center';
                 });
+            });
+
+            function resetSlideScrolling(slide) {
+                $(slide).removeClass('scrollable-slide');
+            }
+            
+            function handleSlideScrolling(slide) {
+                if ($(slide).height() >= 720) {
+                    $(slide).addClass('scrollable-slide');
+                }
+            }
+            
+            Reveal.addEventListener('ready', function (event) {
+                handleSlideScrolling(event.currentSlide);
+            });
+            
+            Reveal.addEventListener('slidechanged', function (event) {
+                resetSlideScrolling(event.previousSlide)
+                handleSlideScrolling(event.currentSlide);
             });
         });
     </script>


### PR DESCRIPTION
Replaces mermaid diagrams with Graphviz.

This means we can render them in advance in mdslides, and avoid the weird rendering but that means diagrams often won't even display correctly.

I did try a mermaid renderer in https://github.com/ferrous-systems/mdslides/pull/23 but it requires headless Chrome, and you can't control the theme.