### PR TITLE
Update bsp-demo

### DIFF
--- a/example-code/nrf52/bsp_demo/.cargo/config.toml
+++ b/example-code/nrf52/bsp_demo/.cargo/config.toml
@@ -2,7 +2,11 @@
 target = "thumbv7em-none-eabihf"
 
 [target.thumbv7em-none-eabihf]
-runner = "probe-run --chip nRF52840_xxAA"
+runner = "probe-rs run --chip nRF52840_xxAA --allow-erase-all"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tdefmt.x",
 ]
+
+[env]
+DEFMT_LOG = "debug"

--- a/example-code/nrf52/bsp_demo/.vscode/launch.json
+++ b/example-code/nrf52/bsp_demo/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "preLaunchTask": "${defaultBuildTask}",
+        "type": "probe-rs-debug",
+        "request": "launch",
+        "name": "Run bsp_demo",
+        "flashingConfig": {
+          "flashingEnabled": true,
+        },
+        "chip": "nrf52840_xxaa",
+        "coreConfigs": [
+          {
+            "programBinary": "./target/thumbv7em-none-eabihf/debug/bsp_demo"
+          }
+        ]
+      }
+    ]
+  }

--- a/example-code/nrf52/bsp_demo/.vscode/launch.json
+++ b/example-code/nrf52/bsp_demo/.vscode/launch.json
@@ -1,20 +1,22 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "preLaunchTask": "${defaultBuildTask}",
-        "type": "probe-rs-debug",
-        "request": "launch",
-        "name": "Run bsp_demo",
-        "flashingConfig": {
-          "flashingEnabled": true,
-        },
-        "chip": "nrf52840_xxaa",
-        "coreConfigs": [
-          {
-            "programBinary": "./target/thumbv7em-none-eabihf/debug/bsp_demo"
-          }
-        ]
-      }
-    ]
-  }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "preLaunchTask": "${defaultBuildTask}",
+      "type": "probe-rs-debug",
+      "request": "launch",
+      "name": "Run bsp_demo",
+      "flashingConfig": {
+        "flashingEnabled": true
+      },
+      "chip": "nrf52840_xxaa",
+      "coreConfigs": [
+        {
+          "coreIndex": 0,
+          "rttEnabled": true,
+          "programBinary": "./target/thumbv7em-none-eabihf/debug/bsp_demo"
+        }
+      ],
+    }
+  ]
+}

--- a/example-code/nrf52/bsp_demo/Cargo.lock
+++ b/example-code/nrf52/bsp_demo/Cargo.lock
@@ -51,11 +51,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bsp_demo"
 version = "0.1.0"
 dependencies = [
- "cortex-m 0.6.7",
+ "cortex-m 0.7.7",
  "cortex-m-rt",
+ "critical-section 1.2.0",
+ "defmt",
+ "defmt-rtt",
  "nrf52840-dk-bsp",
 ]
 
@@ -101,6 +110,7 @@ checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
+ "critical-section 1.2.0",
  "embedded-hal",
  "volatile-register",
 ]
@@ -123,7 +133,7 @@ checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -133,20 +143,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1706d332edc22aef4d9f23a6bb1c92360a403013c291af51247a737472dcae6"
 dependencies = [
  "bare-metal 1.0.0",
- "critical-section 1.1.2",
+ "critical-section 1.2.0",
 ]
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "defmt"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab697b3dbbc1750b7c8b821aa6f6e7f2480b47a99bc057a2ed7b170ebef0c51"
+dependencies = [
+ "critical-section 1.2.0",
+ "defmt",
+]
 
 [[package]]
 name = "embedded-dma"
@@ -306,6 +358,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +465,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
 ]
 
 [[package]]

--- a/example-code/nrf52/bsp_demo/Cargo.toml
+++ b/example-code/nrf52/bsp_demo/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2021"
 
 [dependencies]
 cortex-m-rt = "0.6"
-cortex-m = "0.6"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 nrf52840-dk-bsp = { version = "0.2.0", features = [ "rt" ] }
+defmt = "0.3"
+defmt-rtt = "0.4"
+critical-section = "1.2.0"

--- a/example-code/nrf52/bsp_demo/src/main.rs
+++ b/example-code/nrf52/bsp_demo/src/main.rs
@@ -1,3 +1,7 @@
+//! A simple LED blinking demo for nRF52840-DK
+//!
+//! Demonstrates using a Board Support Package, defmt, and the probe-rs extension for VS Code
+
 #![no_std]
 #![no_main]
 
@@ -5,23 +9,42 @@ use core::fmt::Write;
 use cortex_m_rt::entry;
 use nrf52840_dk_bsp::{hal, Board};
 
+extern crate defmt_rtt;
+
 #[entry]
 fn main() -> ! {
-    let mut nrf52 = Board::take().unwrap();
-    let mut timer = hal::Timer::new(nrf52.TIMER0);
+    // We do some hardware set-up first
+    defmt::info!("Starting up...");
+    let mut board = Board::take().unwrap();
+    let mut timer = hal::Timer::new(board.TIMER0);
+
+    // Now go into an infinite loop
     loop {
-        writeln!(nrf52.cdc, "On!").unwrap();
-        nrf52.leds.led_2.enable();
+        // We're logging over both defmt, and the J-Link's UART to USB Serial
+        // Port interface.
+        defmt::debug!("On!");
+        writeln!(board.cdc, "On!").unwrap();
+
+        // Control the LED
+        board.leds.led_2.enable();
+
+        // Wait for 1 second (this is a 1 MHz timer)
         timer.delay(1_000_000);
-        writeln!(nrf52.cdc, "Off!").unwrap();
-        nrf52.leds.led_2.disable();
+
+        // More logging
+        defmt::debug!("Off!");
+        writeln!(board.cdc, "Off!").unwrap();
+
+        // Control the LED
+        board.leds.led_2.disable();
+
+        // Wait for 1 second again
         timer.delay(1_000_000);
     }
 }
 
 #[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {
-        cortex_m::asm::udf();
-    }
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("Panic! {:?}", defmt::Debug2Format(&info));
+    cortex_m::asm::udf();
 }

--- a/example-code/nrf52/bsp_demo/src/main.rs
+++ b/example-code/nrf52/bsp_demo/src/main.rs
@@ -1,18 +1,21 @@
 #![no_std]
 #![no_main]
 
-use nrf52840_dk_bsp::Board;
-use cortex_m_rt::entry;
 use core::fmt::Write;
+use cortex_m_rt::entry;
+use nrf52840_dk_bsp::{hal, Board};
 
 #[entry]
 fn main() -> ! {
     let mut nrf52 = Board::take().unwrap();
+    let mut timer = hal::Timer::new(nrf52.TIMER0);
     loop {
         writeln!(nrf52.cdc, "On!").unwrap();
         nrf52.leds.led_2.enable();
+        timer.delay(1_000_000);
         writeln!(nrf52.cdc, "Off!").unwrap();
         nrf52.leds.led_2.disable();
+        timer.delay(1_000_000);
     }
 }
 
@@ -22,4 +25,3 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
         cortex_m::asm::udf();
     }
 }
-


### PR DESCRIPTION
1) Slow down the blink rate so it's actually visible on hardware
2) Add a VS Code probe-rs extension launch configuration, to replace https://github.com/knurling-rs/vs-code-gdb-defmt-example
3) Add some defmt logging
