### PR TITLE
add colored text blocks

### DIFF
--- a/training-slides/src/what-is-rust.md
+++ b/training-slides/src/what-is-rust.md
@@ -235,7 +235,7 @@ The Rust Project, and pretty much the whole Community, follow a [Code of
  --> src/main.rs:4:5
   |
 3 |     let nickname = &name[..3];
-  |                     <b style='color:blue;'>---- immutable borrow occurs heree</b>
+  |                     <b style='color:blue;'>---- immutable borrow occurs here</b>
 4 |     name.clear();
   |     <b style='color:red;'>^^^^^^^^^^^^ mutable borrow occurs here</b>
 5 |     println!("Hello there, {}!", nickname);

--- a/training-slides/src/what-is-rust.md
+++ b/training-slides/src/what-is-rust.md
@@ -229,7 +229,6 @@ The Rust Project, and pretty much the whole Community, follow a [Code of
 
 ## Compiler Error Driven Development works!
 
-<section>
 <pre><code data-trim data-noescape>
 <font color="#F15D22"><b>error[E0502]</b></font><b>: cannot borrow `name` as mutable because it is also borrowed as immutable</b>
  <font color="#48B9C7"><b>--&gt; </b></font>src/main.rs:4:5
@@ -243,7 +242,6 @@ The Rust Project, and pretty much the whole Community, follow a [Code of
 <b>Some errors have detailed explanations: E0502, E0596.</b>
 <b>For more information about an error, try `rustc --explain E0502`.</b></pre>
 </code></pre>
-<section>
 
 ## What does Rust run on?
 

--- a/training-slides/src/what-is-rust.md
+++ b/training-slides/src/what-is-rust.md
@@ -229,19 +229,20 @@ The Rust Project, and pretty much the whole Community, follow a [Code of
 
 ## Compiler Error Driven Development works!
 
-```text
-error[E0502]: cannot borrow `name` as mutable because it is also borrowed as immutable
- --> a.rs:4:5
+<section>
+  <pre><code data-trim data-noescape>
+<b style='color:red;'>error[E0502]</b>: cannot borrow `name` as mutable because it is also borrowed as immutable
+ --> src/main.rs:4:5
   |
 3 |     let nickname = &name[..3];
-  |                     ---- immutable borrow occurs here
+  |                     <b style='color:blue;'>---- immutable borrow occurs heree</b>
 4 |     name.clear();
-  |     ^^^^^^^^^^^^ mutable borrow occurs here
+  |     <b style='color:red;'>^^^^^^^^^^^^ mutable borrow occurs here</b>
 5 |     println!("Hello there, {}!", nickname);
-  |                                  -------- immutable borrow later used here
-
-For more information about this error, try `rustc --explain E0502`.
-```
+  |                                  <b style='color:blue;'>-------- immutable borrow later used here</b>
+For more information about this error, try <strong>`rustc --explain E0502`</strong>.
+  </code></pre>
+</section>
 
 ## What does Rust run on?
 

--- a/training-slides/src/what-is-rust.md
+++ b/training-slides/src/what-is-rust.md
@@ -230,19 +230,20 @@ The Rust Project, and pretty much the whole Community, follow a [Code of
 ## Compiler Error Driven Development works!
 
 <section>
-  <pre><code data-trim data-noescape>
-<b style='color:red;'>error[E0502]</b>: cannot borrow `name` as mutable because it is also borrowed as immutable
- --> src/main.rs:4:5
-  |
-3 |     let nickname = &name[..3];
-  |                     <b style='color:blue;'>---- immutable borrow occurs here</b>
-4 |     name.clear();
-  |     <b style='color:red;'>^^^^^^^^^^^^ mutable borrow occurs here</b>
-5 |     println!("Hello there, {}!", nickname);
-  |                                  <b style='color:blue;'>-------- immutable borrow later used here</b>
-For more information about this error, try <strong>`rustc --explain E0502`</strong>.
-  </code></pre>
-</section>
+<pre><code data-trim data-noescape>
+<font color="#F15D22"><b>error[E0502]</b></font><b>: cannot borrow `name` as mutable because it is also borrowed as immutable</b>
+ <font color="#48B9C7"><b>--&gt; </b></font>src/main.rs:4:5
+  <font color="#48B9C7"><b>|</b></font>
+<font color="#48B9C7"><b>3</b></font> <font color="#48B9C7"><b>|</b></font>     let nickname = &amp;name[..3];
+  <font color="#48B9C7"><b>|</b></font>                     <font color="#48B9C7"><b>----</b></font> <font color="#48B9C7"><b>immutable borrow occurs here</b></font>
+<font color="#48B9C7"><b>4</b></font> <font color="#48B9C7"><b>|</b></font>     name.clear();
+  <font color="#48B9C7"><b>|</b></font>     <font color="#F15D22"><b>^^^^^^^^^^^^</b></font> <font color="#F15D22"><b>mutable borrow occurs here</b></font>
+<font color="#48B9C7"><b>5</b></font> <font color="#48B9C7"><b>|</b></font>     println!(&quot;Hello there, {}!&quot;, nickname);
+  <font color="#48B9C7"><b>|</b></font>                                  <font color="#48B9C7"><b>--------</b></font> <font color="#48B9C7"><b>immutable borrow later used here</b></font>
+<b>Some errors have detailed explanations: E0502, E0596.</b>
+<b>For more information about an error, try `rustc --explain E0502`.</b></pre>
+</code></pre>
+<section>
 
 ## What does Rust run on?
 


### PR DESCRIPTION
Fixes #232.

Draft mode while checking out the proof of principle, once that's OK'd I'll go and change the other text blocks, of which there are only 12.

## Proposed solution:

Insert raw HTML under `<code no-escape>` so that the HTML color codes aren't escaped. To get said raw HTML, you can use  `gnome-terminal`,  right-clicking  `Copy as HTML`  and pasting that. 

On macOS, I found VSCode lets you select, then right -click `Copy as HTML` when the error is output from the integrated terminal, and then selecting `Paste As > Insert HTML`.

## Downside:

The source code looks uuuuuugly 🤮 .

Picture 1: What it looks like in browser.

![image](https://github.com/user-attachments/assets/4fc35f93-a361-47ce-8e66-da9da5539641)

Picture 2: What it looks like as slides

![image](https://github.com/user-attachments/assets/e57456c7-98e7-46f7-a44e-b48d1286cfa1)

## Alternative solution

Use this crate (which is what the compiler team uses) https://docs.rs/anstyle-svg/latest/anstyle_svg/#example, though I don't see how serving SVGs is much better as an overall workflow.