### PR TITLE
xtask cheatsheets: add unit tests and handle slide deck title corner case

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@
 //! Spawns varies tasks, according to the command-line arguments.
 
 #![deny(warnings)]
+#![deny(missing_docs)]
 
 mod tasks;
 
@@ -65,7 +66,7 @@ fn main() -> color_eyre::Result<()> {
 
     match &args[..] {
         ["make-cheatsheet", lang] => tasks::make_cheatsheet(lang),
-        ["test-cheatsheet", lang] => tasks::test_cheatsheet(lang),
+        ["test-cheatsheet", lang] => tasks::setup_cheatsheet_tester(lang),
         _ => Ok(()),
     }
 }

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -30,7 +30,7 @@
 //! The other half of the functionality is `test-cheatsheets`, which requires thinking
 //! about what would make our `cheatsheets` fall out of sync.
 //!
-//! Assume we have a folder with `src/*-cheatsheets.md`.
+//! Assume we have a folder with `src/mylang-cheatsheets.md`.
 //!
 //! In theory, the cheatsheets and the files in `SUMMARY.md` need to have
 //!
@@ -227,6 +227,15 @@ pub fn test_cheatsheet(lang: &str) -> Result<(), eyre::Report> {
     let file_name = format!("./training-slides/src/{lang}-cheatsheet.md");
     let cheatsheet_text = read_to_string(file_name)
         .with_context(|| eyre::eyre!("{lang}-cheatsheet.md not found."))?;
+    // TODO: Check for slide title for slide mode
+    // TODO: Add unit test for previous panic
+    // TODO: separate file handling from correctness logic
+    // Safety: We know `lang` is part of our blessed lang-names, so it must be at least of size 1.
+    let lang_uppercase = lang.chars().nth(1).unwrap().to_uppercase().to_string() + &lang[1..];
+    let cheatsheet_name = format!("# {lang_uppercase} Cheatsheet");
+    if !cheatsheet_text.contains(&cheatsheet_name) {
+        panic!("{lang}-cheatsheet.md does not contain a starting header `{cheatsheet_name}`");
+    }
 
     let mut chunked_cheatsheet: Vec<Vec<String>> = Vec::new();
     let mut current_section: Vec<String> = Vec::new();
@@ -295,7 +304,6 @@ pub fn test_cheatsheet(lang: &str) -> Result<(), eyre::Report> {
     if missing_files {
         panic!("You have missing slides in {lang}-cheatsheet.md");
     } else {
-        eprintln!("Neat! {lang}-cheatsheet.md is in sync");
         Ok(())
     }
 }
@@ -401,5 +409,14 @@ Rust for the Linux Kernel and other no-std environments with an pre-existing C A
         let region = focus_regions(test);
         assert_eq!(list_of_strings_to_slide_section(&region[0]), res);
         assert!(true);
+    }
+    #[test]
+    fn test_cheatsheet_lang() {
+
+    }
+    #[test]
+    #[should_panic]
+    fn test_no_opening_title() {
+
     }
 }

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -228,9 +228,6 @@ pub fn test_cheatsheet(lang: &str) -> Result<(), eyre::Report> {
 }
 
 fn cheatsheet_tester(lang: &str, slide_sections: Vec<SlidesSection>, cheatsheet_text: &str) -> Result<(), eyre::Error> {
-    // TODO: Check for slide title for slide mode
-    // TODO: Add unit test for previous panic
-    // TODO: separate file handling from correctness logic
     // Safety: We know `lang` is part of our blessed lang-names, so it must be at least of size 1.
     let lang_uppercase = lang.chars().nth(0).unwrap().to_uppercase().to_string() + &lang[1..];
     let cheatsheet_name = format!("# {lang_uppercase} Cheatsheet");
@@ -242,6 +239,7 @@ fn cheatsheet_tester(lang: &str, slide_sections: Vec<SlidesSection>, cheatsheet_
     let mut current_section: Vec<String> = Vec::new();
 
     // Skip anything that doesn't start with '#', we don't care about them.
+    // Also, skip the line if it's `# Mylang Cheatsheet`
     for line in cheatsheet_text.lines() {
         if line.is_empty() || !line.starts_with('#') || line == cheatsheet_name {
             continue;
@@ -305,6 +303,7 @@ fn cheatsheet_tester(lang: &str, slide_sections: Vec<SlidesSection>, cheatsheet_
     if missing_files {
         panic!("You have missing slides in {lang}-cheatsheet.md");
     } else {
+        eprintln!("Neat! {lang}-cheatsheet.md is in sync");
         Ok(())
     }
 }

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -182,7 +182,7 @@ pub fn make_cheatsheet(lang: &str) -> Result<(), eyre::Report> {
     let text = read_to_string("./training-slides/src/SUMMARY.md").context("SUMMARY.md not found")?;
     let slide_texts = focus_regions(&text);
     let uppercase_lang_name = lang.chars().nth(0).unwrap().to_uppercase().to_string() + &lang[1..];
-    let mut slide_sections = vec![SlidesSection { header: format!("# {uppercase_lang_name} Cheatsheet"), deck_titles: vec!["\n".into()] }];
+    let mut slide_sections = vec![SlidesSection { header: format!("{uppercase_lang_name} Cheatsheet"), deck_titles: vec![] }];
     slide_texts
         .iter()
         .for_each(|l| slide_sections.push(list_of_strings_to_slide_section(l)));


### PR DESCRIPTION
This PR adds the functionality so that the cpp cheatsheet skeleton in #250 can be properly produced, tested, and maintained.

TL;DR:

Before, we would write out the slides like this for a `cpp-cheatsheet.md`:

```text
# Rust Fundamentals
## Overview
## Basic Types
...
```

Whereas it needed to be like this

```text
# Cpp Cheatsheet
# Rust Fundamentals
## Overview
## Basic Types
```

so that the slide form was properly displayed.

The rest of the PR is the unit tests to justify said change and refactoring of some logic into its own function to facilitate said tests.