### PR TITLE
Link to channel description docs

### DIFF
--- a/training-slides/src/ferrocene-installing.md
+++ b/training-slides/src/ferrocene-installing.md
@@ -51,6 +51,9 @@ Examples of releases include:
 * stable-24.08.0
 * etc
 
+See <https://public-docs.ferrocene.dev/main/qualification/plan/release.html>
+for details about our release channels.
+
 ---
 
 ![Portal](./images/portal-docs.png)

--- a/training-slides/src/ferrocene-what-it-is.md
+++ b/training-slides/src/ferrocene-what-it-is.md
@@ -60,7 +60,11 @@ As of 3 September 2024, the Ferrocene releases are:
 Note:
 
 We strive to make each stable release available for two years, including
-tracking of Known Problems.
+tracking of Known Problems. The nightly, pre-rolling and rolling releases do not
+carry our stability or support guarantees - they only apply to our *stable-xxx*
+releases. See
+<https://public-docs.ferrocene.dev/main/qualification/plan/release.html> for
+details.
 
 ## Open Source
 


### PR DESCRIPTION
Links to https://public-docs.ferrocene.dev/main/qualification/plan/release.html which describes our channel policy.