### PR TITLE
avoid [stable,beta,nightly] matrix failing fast

### DIFF
--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -8,6 +8,7 @@ jobs:
   weekly-canary-build:
     strategy:
         matrix:
+            fail-fast: false
             rust-channel: [stable, beta, nightly]
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This should make it so all jobs run even if one of stable/beta/nightly fails.