### PR TITLE
speed up ci (no caching)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+
 jobs:
   build-slides:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test all cheatsheets
         run: |
-          cargo xtask test-all-cheatsheets
+          cargo xtask test-all-cheatsheets --locked
 
       - name: Assemble Artifacts
         run: |

--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Test all cheatsheets
         run: |
-          cargo xtask test-all-cheatsheets
+          cargo xtask test-all-cheatsheets --locked

--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * Mon'
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+
 jobs:
   weekly-canary-build:
     strategy:

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 if [ $(uname) == "Darwin" ]; then
     ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-apple-darwin.tar.gz | tar -xvzf -
     dot -V || brew install graphviz
-    mdbook-graphviz --version || cargo install mdbook-graphviz
+    mdbook-graphviz --version || cargo install mdbook-graphviz --locked
     ./mdbook-mermaid --version || curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-apple-darwin.tar.gz | tar -xvzf -
     ./mdslides --version || ( curl -sSL https://github.com/ferrous-systems/mdslides/releases/download/v0.6.1/mdslides-x86_64-apple-darwin.tar.xz | tar -xvJf - \
         && mv ./mdslides-*/mdslides . \

--- a/example-code/build-ferrocene.sh
+++ b/example-code/build-ferrocene.sh
@@ -6,16 +6,16 @@ set -euo pipefail
 pushd ./qemu-aarch64v8a
 criticalup install
 ./build.sh "$(criticalup which rustc)"
-criticalup run cargo build --release
+criticalup run cargo build --release --locked
 popd
 # And the qemu Aarch32 Armv8-R/Armv7-R example
 pushd ./qemu-aarch32v78r
 criticalup install
-criticalup run cargo build --release
-criticalup run cargo build --target=armv7r-none-eabihf --release
+criticalup run cargo build --release --locked
+criticalup run cargo build --target=armv7r-none-eabihf --release --locked
 popd
 # Build qemu Armv7E-M example
 pushd qemu-thumbv7em
 criticalup install
-criticalup run cargo build
+criticalup run cargo build --locked
 popd

--- a/example-code/build.sh
+++ b/example-code/build.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 
 # Check the example code
 pushd ./native/ffi/use-c-in-rust
-cargo build --all
-cargo test
+cargo build --all --locked
+cargo test --locked
 popd
 pushd ./native/stdout
-cargo build --all
+cargo build --all --locked
 popd
 # And the C based example
 pushd native/ffi/use-rust-in-c
@@ -17,22 +17,22 @@ make clean
 popd
 # And the nRF52 examples
 pushd ./nrf52/bsp_demo
-cargo build --release
+cargo build --release --locked
 popd
 # Build qemu Aarch64 Armv8-A example
 pushd ./qemu-aarch64v8a
 ./build.sh
-cargo build
+cargo build --locked
 popd
 # Build qemu Aarch32 Armv8-R/Armv7-R example
 pushd ./qemu-aarch32v78r
 # Can't use the shell script or the default target becuase armv8r isn't available
 # outside Ferrocene
 # ./build.sh
-cargo build --target=armv7r-none-eabihf
+cargo build --target=armv7r-none-eabihf --locked
 popd
 # Build qemu Armv7E-M example
 pushd qemu-thumbv7em
-cargo build
+cargo build --locked
 popd
 

--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
@@ -113,7 +113,7 @@
     </Link>
     <PreBuildEvent>
       <Command>cd $(ProjectDir)\..
-cargo build
+cargo build --locked
 </Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -139,7 +139,7 @@ cargo build
     </Link>
     <PreBuildEvent>
       <Command>cd $(ProjectPath)\..
-cargo build --release
+cargo build --release --locked
 </Command>
     </PreBuildEvent>
     <PreBuildEvent>


### PR DESCRIPTION
This PR seeks to speed up CI by using low hanging fruit strategies:
* minimizing cargo doing version resolution with `--locked`
* disabling incremental compilation
* disabling debug info emission

A separate PR will try to cache some of the worst offenders - 