### PR TITLE
fail-fast is on strategy: key

### DIFF
--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -11,8 +11,8 @@ env:
 jobs:
   weekly-canary-build:
     strategy:
+        fail-fast: false
         matrix:
-            fail-fast: false
             rust-channel: [stable, beta, nightly]
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
The weekly canary failed. 

This should help it run properly.