### PR TITLE
add oneline log to probe-rs in defmt.md

### DIFF
--- a/training-slides/src/defmt.md
+++ b/training-slides/src/defmt.md
@@ -234,9 +234,9 @@ $ probe-rs run --chip nRF52840_xxAA ... --log-format oneline
 <span class="eg b">      Erasing</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 35.52 KiB/s (eta 0s )
 <span class="eg b">  Programming</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 49.90 KiB/s (eta 0s )
 <span class="eg b">     Finished</span> in 0.79s
-00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr">dk</span> dk/src/lib.rs:317)
-00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr">dk</span> dk/src/lib.rs:335)
-00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr">dk</span> dk/src/lib.rs:354)
+00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr b">dk</span> dk/src/lib.rs:317)
+00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr b">dk</span> dk/src/lib.rs:335)
+00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr b">dk</span> dk/src/lib.rs:354)
 </code></pre>
 
 ## Set it as your runner

--- a/training-slides/src/defmt.md
+++ b/training-slides/src/defmt.md
@@ -243,13 +243,13 @@ $ probe-rs run --chip nRF52840_xxAA ... --log-format oneline
 
 ```toml
 [target.thumbv7em-none-eabihf]
-runner = "probe-rs run --chip nRF52840_xxAA"
+runner = "probe-rs run --chip nRF52840_xxAA --log-format oneline"
 ```
 
 <pre><code data-trim data-noescape>
 $ cargo run
 <span class="eg b">    Finished</span> dev [optimized + debuginfo] target(s) in 0.03s
-<span class="eg b">     Running</span> `probe-rs run --chip nRF52840_xxAA target/thumbv7em-none-eabihf/debug/radio-puzzle-solution`
+<span class="eg b">     Running</span> `probe-rs run --chip nRF52840_xxAA  --log-format oneline target/thumbv7em-none-eabihf/debug/radio-puzzle-solution`
 <span class="eg b">     Erasing</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 35.52 KiB/s (eta 0s )
 <span class="eg b"> Programming</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 49.90 KiB/s (eta 0s )
 <span class="eg b">    Finished</span> in 0.79s

--- a/training-slides/src/defmt.md
+++ b/training-slides/src/defmt.md
@@ -230,12 +230,13 @@ $ probe-rs run --chip nRF52840_xxAA target/thumbv7em-none-eabihf/debug/radio-puz
 ## Customise the format
 
 <pre><code data-trim data-noescape>
-$ probe-rs run --chip nRF52840_xxAA ... --log-format "{t} {f}:{l} {L} {s}"
+$ probe-rs run --chip nRF52840_xxAA ... --log-format oneline
 <span class="eg b">      Erasing</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 35.52 KiB/s (eta 0s )
 <span class="eg b">  Programming</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 49.90 KiB/s (eta 0s )
 <span class="eg b">     Finished</span> in 0.79s
-0 lib.rs:208  DEBUG Initializing the board
-1 lib.rs:219  DEBUG Clocks configured
+00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr">dk</span> dk/src/lib.rs:317)
+00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr">dk</span> dk/src/lib.rs:335)
+00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr">dk</span> dk/src/lib.rs:354)
 </code></pre>
 
 ## Set it as your runner
@@ -252,10 +253,9 @@ $ cargo run
 <span class="eg b">     Erasing</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 35.52 KiB/s (eta 0s )
 <span class="eg b"> Programming</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 49.90 KiB/s (eta 0s )
 <span class="eg b">    Finished</span> in 0.79s
-0 DEBUG Initializing the board
-└─ dk::init @ /Users/jp/ferrous-systems/rust-exercises/nrf52-code/boards/dk/src/lib.rs:208
-1 DEBUG Clocks configured
-└─ dk::init @ /Users/jp/ferrous-systems/rust-exercises/nrf52-code/boards/dk/src/lib.rs:219
+00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr">dk</span> dk/src/lib.rs:317)
+00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr">dk</span> dk/src/lib.rs:335)
+00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr">dk</span> dk/src/lib.rs:354)
 </code></pre>
 
 ## More info

--- a/training-slides/src/defmt.md
+++ b/training-slides/src/defmt.md
@@ -253,9 +253,9 @@ $ cargo run
 <span class="eg b">     Erasing</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 35.52 KiB/s (eta 0s )
 <span class="eg b"> Programming</span> ✔ [00:00:00] [#########################] 16.00 KiB/16.00 KiB @ 49.90 KiB/s (eta 0s )
 <span class="eg b">    Finished</span> in 0.79s
-00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr">dk</span> dk/src/lib.rs:317)
-00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr">dk</span> dk/src/lib.rs:335)
-00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr">dk</span> dk/src/lib.rs:354)
+00:00:00.000000 <span class="b">[DEBUG]</span> Initializing the board (<span class="gr b">dk</span> dk/src/lib.rs:317)
+00:00:00.000000 <span class="b">[DEBUG]</span> Clocks configured (<span class="gr b">dk</span> dk/src/lib.rs:335)
+00:00:00.000000 <span class="b">[DEBUG]</span> RTC started (<span class="gr b">dk</span> dk/src/lib.rs:354)
 </code></pre>
 
 ## More info

--- a/training-slides/theme/head.hbs
+++ b/training-slides/theme/head.hbs
@@ -29,4 +29,8 @@ Load mermaid from the CDN.
         font-weight: bold;
         color: #00FFFF;
     }
+    pre code .gr {
+        font-weight: bold;
+        color: #808080;
+    }
 </style>


### PR DESCRIPTION
Switching over to demoing the `--logformat oneline` format, but using black bold instead because our background is white, and the subsequent gray doesn't pop as much.

It's enough for demo'ing that it's nice and clean and we point trainees to read more materials, so I don't see the disparity between our presentation and the one that is likely to come out of their terminals as warranting blocking this.