### PR TITLE
Update runners to Ubuntu 24.04.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           artifacts: ./rust-training-${{ env.slug }}.zip
 
   build-examples-ferrocene:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
      
@@ -114,7 +114,7 @@ jobs:
             ./rust-training-*/
 
   build-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
      


### PR DESCRIPTION
The Ubuntu 20.04 running is heading for EOL.