### PR TITLE
Canary runs weekly again.

### DIFF
--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -2,7 +2,7 @@ name: Weekly Canary Build
 
 on:
   schedule:
-    - cron: '50 8 * * *'
+    - cron: '45 7 * * Mon' # 07:45 UTC on Monday
 
 env:
   CARGO_TERM_COLORS: always    # We want colors in our CI output


### PR DESCRIPTION
I moved it to 07:45 to avoid the inevitable rush that occurs at the stroke of midnight UTC, when all the world's daily / weekly / monthly cron jobs run. As long as it's before Europe gets to work on a Monday morning, it's fine.