### PR TITLE
Removes all line numbers from text blocks

### DIFF
--- a/training-slides/src/advanced-strings.md
+++ b/training-slides/src/advanced-strings.md
@@ -53,7 +53,7 @@ digraph {
 
 ## Creation
 
-```rust []
+```rust
 fn main() {
     // &'static str
     let this = "Hello";
@@ -74,7 +74,7 @@ fn main() {
 
 Just because multiple types exist doesn't mean they can't work in harmony.
 
-```rust []
+```rust
 fn main() {
     let part_one = String::from("Hello ");
     let part_two = String::from("there ");
@@ -123,7 +123,7 @@ It is strongly recommended you read *all* of the [documentation](https://doc.rus
 
 Splitting:
 
-```rust []
+```rust
 fn main() {
     let words = "Cow says moo";
     let each: Vec<_> = words.split(" ").collect();
@@ -135,7 +135,7 @@ fn main() {
 
 Concatenation:
 
-```rust []
+```rust
 fn main() {
     let animal = String::from("Cow");
     let sound = String::from("moo");
@@ -148,7 +148,7 @@ fn main() {
 
 Replacing:
 
-```rust []
+```rust
 fn main() {
     let words = "Cow says moo";
     let replaced = words.replace("moo", "roar");
@@ -160,7 +160,7 @@ fn main() {
 
 It's possible to accept either rather painlessly:
 
-```rust []
+```rust
 fn accept_either<S>(thing: S) -> String
 where S: AsRef<str> {
     String::from("foo") + thing.as_ref()
@@ -179,7 +179,7 @@ fn main() {
 -   Can span multiple lines, leading spaces become part of the line
 -   Escape sequences are not processed
 
-```rust []
+```rust
 fn main () {
     let json = r##"
 {
@@ -196,7 +196,7 @@ fn main () {
 * not really strings
 * used to declare static byte slices (have a `&[u8]` type)
 
-```rust []
+```rust
 fn main() {
     let byte_string: &[u8] = b"allows ASCII and \xF0\x9F\x98\x80 only";
     println!("Can Debug fmt but not Display fmt: {:?}", byte_string);

--- a/training-slides/src/async-building-blocks.md
+++ b/training-slides/src/async-building-blocks.md
@@ -13,7 +13,7 @@
 
 ## An async Rust function
 
-```rust [], ignore
+```rust, ignore
 use tokio::{fs::File, io::AsyncReadExt};
 
 async fn read_from_disk(path: &str) -> std::io::Result<String> {
@@ -27,7 +27,7 @@ async fn read_from_disk(path: &str) -> std::io::Result<String> {
 
 ## (sketch) Desugaring return type
 
-```rust [], ignore
+```rust, ignore
 use std::future::Future;
 
 use tokio::{fs::File, io::AsyncReadExt};
@@ -69,7 +69,7 @@ They can be checked if they are _done_, and are usually mapped to readiness base
 
 ## .await registers interest in completion
 
-```rust [], ignore
+```rust, ignore
 use tokio::{fs::File, io::AsyncReadExt};
 
 async fn read_from_disk(path: &str) -> std::io::Result<String> {
@@ -83,7 +83,7 @@ async fn read_from_disk(path: &str) -> std::io::Result<String> {
 
 ## Futures are cold
 
-```rust [], ignore
+```rust, ignore
 fn main() {
     let read_from_disk_future = read_from_disk();
 }
@@ -91,7 +91,7 @@ fn main() {
 
 ## Futures need to be executed
 
-```rust [], ignore
+```rust, ignore
 use tokio::{fs::File, io::AsyncReadExt};
 
 #[tokio::main]
@@ -124,7 +124,7 @@ async fn read_from_disk(path: &str) -> std::io::Result<String> {
 
 ## Futures all the way down: Combining Futures
 
-```rust [], ignore
+```rust, ignore
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tokio::time::Duration;
@@ -184,7 +184,7 @@ async fn main() {
 
 ## Async iteration
 
-```rust [], ignore
+```rust, ignore
 while let Some(item) = stream.next().await {
     //...
 }

--- a/training-slides/src/async-component-interaction.md
+++ b/training-slides/src/async-component-interaction.md
@@ -18,7 +18,7 @@ It's hard to determine for a full program if _all instances of a task are stayin
 
 * `spawn_blocking` is usually the solution for dealing with slightly longer tasks
 
-```rust [], ignore
+```rust, ignore
 task::spawn_blocking(async {
     std::thread::sleep(Duration::from_secs(1000));
 });
@@ -50,7 +50,7 @@ task::spawn_blocking(async {
 
 ## Example
 
-```rust [], ignore
+```rust, ignore
 let (s, r) = mpsc::channel(32);
 
 assert_eq!(s.send("Hello").await, Ok(()));

--- a/training-slides/src/async-implementation-details.md
+++ b/training-slides/src/async-implementation-details.md
@@ -15,7 +15,7 @@
 
 ## Tasks example
 
-```rust [], ignore
+```rust, ignore
 async fn learn_and_sing() {
     let song = learn_song().await;  // 1
     sing_song(song).await;          // 2
@@ -42,7 +42,7 @@ async fn learn_and_sing() {
 
 ## Pin Example
 
-```rust [], ignore
+```rust, ignore
 #[tokio::main]
 async fn main() {
     let mut stream = async_stream();

--- a/training-slides/src/async-intro-to-tokio.md
+++ b/training-slides/src/async-intro-to-tokio.md
@@ -21,7 +21,7 @@
 
 ## Example Mio
 
-```rust [], ignore
+```rust, ignore
 let addr = "127.0.0.1:13265".parse()?;
 let mut server = TcpListener::bind(addr)?;
 // Start listening for incoming connections.
@@ -43,7 +43,7 @@ poll.registry()
 
 ## Example Tokio
 
-```rust [], ignore
+```rust, ignore
 #[tokio::main]
 async fn main() {
     // Bind the listener to the address
@@ -64,7 +64,7 @@ async fn main() {
 
 ## Example Hyper
 
-```rust [], ignore
+```rust, ignore
 #[tokio::main]
 async fn main() {
     // We'll bind to 127.0.0.1:3000

--- a/training-slides/src/basic-types.md
+++ b/training-slides/src/basic-types.md
@@ -91,7 +91,7 @@ Boolean in Rust is represented by either of two values: `true` or
 
 ## Character Literals
 
-```rust [2-3|4-5|6-7|8-9]
+```rust
 fn main() {
     // U+0072 LATIN SMALL LETTER R
     let ascii_char = 'r';
@@ -130,7 +130,7 @@ fn main() {
 * Slices carry a pointer to some other array, and a length.
 * Slices cannot be resized but can be subsliced.
 
-```rust [2|3]
+```rust
 fn main() {
     let slice: &[i32] = &[1, 2, 3, 4];
     let sub: &[i32] = &slice[0..1];

--- a/training-slides/src/closures.md
+++ b/training-slides/src/closures.md
@@ -102,7 +102,7 @@ fn main() {
 * But why is this useful?
 * It makes iterators really powerful!
 
-```rust []
+```rust
 fn main() {
     let items = [1, 2, 3, 4, 5, 6];
     let n = 2;
@@ -120,7 +120,7 @@ It's also very powerful if you have something you need to clean up.
 2. You want do some work (defined by the caller)
 3. You want to clean up after.
 
-```rust []
+```rust
 fn setup_teardown<F, T>(f: F) -> T where F: FnOnce(&mut Vec<u32>) -> T {
     let mut state = Vec::new();
     println!("> Setting up state");
@@ -132,7 +132,7 @@ fn setup_teardown<F, T>(f: F) -> T where F: FnOnce(&mut Vec<u32>) -> T {
 
 ## Cleaning up
 
-```rust []
+```rust
 fn setup_teardown<F, T>(f: F) -> T where F: FnOnce(&mut Vec<u32>) -> T {
     let mut state = Vec::new();
     println!("> Setting up state");

--- a/training-slides/src/collections.md
+++ b/training-slides/src/collections.md
@@ -4,7 +4,7 @@
 
 Arrays (`[T; N]`) have a fixed size.
 
-```rust []
+```rust
 fn main() {
     let array = [1, 2, 3, 4, 5];
     println!("array = {:?}", array);
@@ -29,7 +29,7 @@ digraph {
 
 How do you know how many 'slots' you've used?
 
-```rust []
+```rust
 fn main() {
     let mut array = [0u8; 10];
     for idx in 0..5 {
@@ -57,7 +57,7 @@ digraph {
 
 A view into *some other data*. Written as `&[T]` (or `&mut [T]`).
 
-```rust [1-8|6]
+```rust
 fn main() {
     let mut array = [0u8; 10];
     for idx in 0..5 {
@@ -93,7 +93,7 @@ Slices are *unsized* types and can only be access via a reference. This referenc
 
 `Vec` is a growable, heap-allocated, array-like type.
 
-```rust []
+```rust
 fn process_data(input: &[u32]) {
     let mut vector = Vec::new();
     for value in input {
@@ -192,7 +192,7 @@ A string slice is tied to the lifetime of the data that it refers to.
 * String Literals produce a string slice "with static lifetime"
 * Points at some bytes that live in read-only memory with your code
 
-```rust []
+```rust
 fn main() {
     let s: &'static str = "Hello!";
     println!("s = {}", s);
@@ -262,7 +262,7 @@ The green block of data is heap allocated.
 
 ## Making a String
 
-```rust [1-7|2|3|4|5|6]
+```rust
 fn main() {
     let s1 = "String literal up-conversion".to_string();
     let s2: String = "Into also works".into();
@@ -274,7 +274,7 @@ fn main() {
 
 ## Appending to a String
 
-```rust [1-7|2|3|4|5-6]
+```rust
 fn main() {
     let mut start = "Mary had a ".to_string();
     start.push_str("little");
@@ -286,7 +286,7 @@ fn main() {
 
 ## Joining pieces of String
 
-```rust [1-5|2|3|4]
+```rust
 fn main() {
     let pieces = ["Mary", "had", "a", "little", "lamb"];
     let rhyme = pieces.join(" ");
@@ -298,7 +298,7 @@ fn main() {
 
 A ring-buffer, also known as a Double-Ended Queue:
 
-```rust []
+```rust
 use std::collections::VecDeque;
 fn main() {
     let mut queue = VecDeque::new();
@@ -366,7 +366,7 @@ fn entry(&mut self, key: K) -> Entry<K, V> {
 
 ## Entry API Example
 
-```rust []
+```rust
 use std::collections::HashMap;
  
 fn update_connection(map: &mut HashMap<i32, u64>, id: i32) {

--- a/training-slides/src/compound-types.md
+++ b/training-slides/src/compound-types.md
@@ -6,7 +6,7 @@ A `struct` groups and names data of different types.
 
 ## Definition
 
-```rust []
+```rust
 struct Point {
     x: i32,
     y: i32,
@@ -22,7 +22,7 @@ you ask the compiler to [ensure that they are](https://doc.rust-lang.org/nomicon
 
 - there is no partial initialization
 
-```rust [1-4|6-8]
+```rust
 struct Point {
     x: i32,
     y: i32,
@@ -37,7 +37,7 @@ fn main() {
 
 - but you can copy from an existing variable of the same type
 
-```rust [8]
+```rust
 struct Point {
     x: i32,
     y: i32,
@@ -51,7 +51,7 @@ fn main() {
 
 ## Field Access
 
-```rust [1-4|7|8-9]
+```rust
 struct Point {
     x: i32,
     y: i32,
@@ -69,7 +69,7 @@ fn main() {
 - Holds values of different types together.
 - Like an anonymous `struct`, with fields numbered 0, 1, etc.
 
-```rust [2|3-4]
+```rust
 fn main() {
     let p = (1, 2);
     println!("{}", p.0);
@@ -93,7 +93,7 @@ fn prints_but_returns_nothing(data: &str) -> () {
 
 - Like a `struct`, with fields numbered 0, 1, etc.
 
-```rust [1|4|5-6]
+```rust
 struct Point(i32,i32);
 
 fn main() {
@@ -117,7 +117,7 @@ fn main() {
 
 ## enum: Definition and Construction
 
-```rust [1-6|9]
+```rust
 enum Shape {
     Square,
     Circle,
@@ -132,7 +132,7 @@ fn main() {
 
 ## Enums with Values
 
-```rust [1-6|2-4|5|9|10]
+```rust
 enum Movement {
     Right(i32),
     Left(i32),
@@ -165,7 +165,7 @@ and a `union`.
 - When an `enum` has variants, you use `match` to extract the data
 - New variables are created from the *pattern* (e.g. `radius`)
 
-```rust [1-4|7-14|8|11]
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),
@@ -186,18 +186,17 @@ fn check_shape(shape: Shape) {
 ## Doing a `match` on an `enum`
 
 - There are two variables called `radius`
-- The binding of `radius` in the pattern on line 9 hides the `radius` variable on line 7
 
-```rust [7|9]
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),
 }
 
 fn check_shape(shape: Shape) {
-    let radius = 10;
+    let radius = 10; /* gets hidden */
     match shape {
-        Shape::Circle(radius) => {
+        Shape::Circle(radius) => { /* by this **new** variable */
             println!("It's a circle, with radius {}", radius);
         }
         _ => {
@@ -211,7 +210,7 @@ fn check_shape(shape: Shape) {
 
 Match guards allow further refining of a `match`
 
-```rust [8]
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),
@@ -233,7 +232,7 @@ fn check_shape(shape: Shape) {
 
 - You can use the `|` operator to join patterns together
 
-```rust [1-16|9]
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),
@@ -257,7 +256,7 @@ fn test_shape(shape: Shape) {
 - You can use `if let` if only one case is of interest.
 - Still *pattern matching*
 
-```rust []
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),
@@ -275,7 +274,7 @@ fn test_shape(shape: Shape) {
 - If you expect it to match, but want to handle the error...
 - The `else` block must *diverge*
 
-```rust []
+```rust
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),

--- a/training-slides/src/control-flow.md
+++ b/training-slides/src/control-flow.md
@@ -15,7 +15,7 @@
 - Parentheses around the conditional are not necessary
 - Blocks need brackets, no shorthand
 
-```rust []
+```rust
 fn main() {
     if 1 == 2 {
         println!("integers are broken");
@@ -32,7 +32,7 @@ fn main() {
 - Every block is an expression
 - Note the final `;` to terminate the `let` statement.
 
-```rust []
+```rust
 fn main() {
     let x = if 1 == 2 {
         100
@@ -48,7 +48,7 @@ fn main() {
 
 Now the `if` expression is the result of the function:
 
-```rust []
+```rust
 fn some_function() -> i32 {
     if 1 == 2 {
         100
@@ -64,7 +64,7 @@ fn some_function() -> i32 {
 
 `loop` is used for (potentially) infinite loops
 
-```rust []
+```rust
 fn main() {
     let mut i = 0;
     loop {
@@ -78,7 +78,7 @@ fn main() {
 
 `loop` blocks are also expressions...
 
-```rust []
+```rust
 fn main() {
     let mut i = 0;
     let loop_result = loop {
@@ -95,7 +95,7 @@ fn main() {
 - `while` is used for conditional loops.
 - Loops while the boolean expression is `true`
 
-```rust []
+```rust
 fn main() {
     let mut i = 0;
     while i < 10 {
@@ -112,7 +112,7 @@ fn main() {
 - The first arm to match, wins
 - `_` means *match anything*
 
-```rust []
+```rust
     fn main() {
         let a = 4;
         match a % 3 {
@@ -127,7 +127,7 @@ fn main() {
 - `for` is used for iteration
 - Here `0..10` creates a `Range`, which you can iterate
 
-```rust []
+```rust
 fn main() {
     for num in 0..10 {
         println!("{}", num);
@@ -139,7 +139,7 @@ fn main() {
 
 Lots of things are *iterable*
 
-```rust []
+```rust
 fn main() {
     for ch in "Hello".chars() {
         println!("{}", ch);
@@ -152,7 +152,7 @@ fn main() {
 - What Rust actually does is more like...
 - (More on this in the section on *Iterators*)
 
-```rust []
+```rust
 fn main() {
     let mut iter = "Hello".chars().into_iter();
     loop {
@@ -168,7 +168,7 @@ fn main() {
 
 If you have nested loops, you can label them to indicate which one you want to break out of.
 
-```rust []
+```rust
 fn main() {
     'cols: for x in 0..5 {
         'rows: for y in 0..5 {
@@ -185,7 +185,7 @@ fn main() {
 
 Means go around the loop again, rather than break out of the loop
 
-```rust []
+```rust
 fn main() {
     'cols: for x in 0..5 {
         'rows: for y in 0..5 {
@@ -203,7 +203,7 @@ fn main() {
 - `return` can be used for early returns
 - The result of the last expression of a function is always returned
 
-```rust []
+```rust
 fn get_number(x: bool) -> i32 {
     if x {
         return 42;

--- a/training-slides/src/cpp-cheatsheet.md
+++ b/training-slides/src/cpp-cheatsheet.md
@@ -45,7 +45,7 @@ for (const auto &: list) {
 
 is equivalent to
 
-```rust [], ignore
+```rust, ignore
 for value in &list {
     //...
 }

--- a/training-slides/src/dealing-with-unwrap.md
+++ b/training-slides/src/dealing-with-unwrap.md
@@ -27,7 +27,7 @@ Let's see how we can get to `?` as quickly as possible in cases where
 
 `?` turns this
 
-```rust [], ignore
+```rust, ignore
 fn write_info(info: &Info) -> io::Result<()> {
     // Early return on error
     let mut file = match File::create("my_best_friends.txt") {
@@ -51,7 +51,7 @@ fn write_info(info: &Info) -> io::Result<()> {
 
 Into this
 
-```rust [], ignore
+```rust, ignore
 fn write_info(info: &Info) -> io::Result<()> {
     let mut file = File::create("my_best_friends.txt")?;
     // Early return on error
@@ -68,7 +68,7 @@ fn write_info(info: &Info) -> io::Result<()> {
 
 As well as this
 
-```rust []
+```rust
 fn add_last_numbers(stack: &mut Vec<i32>) -> Option<i32> {
     let a = stack.pop();
     let b = stack.pop();
@@ -82,7 +82,7 @@ fn add_last_numbers(stack: &mut Vec<i32>) -> Option<i32> {
 
 ## `?` vs Pattern Matching 2
 
-```rust []
+```rust
 fn add_last_numbers(stack: &mut Vec<i32>) -> Option<i32> {
     Some(stack.pop()? + stack.pop()?)
 }
@@ -94,7 +94,7 @@ We prefer using `?` instead of highly nested pattern matching
 
 * Sometimes we return `Option`, but we want a `Result` because it adds more context:
 
-```rust [], ignore
+```rust, ignore
 struct UserId {
     name: String,
     num: u32,
@@ -110,7 +110,7 @@ fn find_user(username: &str) -> Option<&str> {
 
 ## Option into Result: After
 
-```rust [], ignore
+```rust, ignore
 struct UserId {
     name: String,
     num: u32,
@@ -129,7 +129,7 @@ pub fn find_user(username: &str) -> Result<UserId, i32> {
 * We can process the context of the error to produce something more meaningful than `i32`
 * Concretely: use `map_err()` on a `Result<_, A>` to get a `Result<_, B>`
 
-```rust [], ignore
+```rust, ignore
 pub fn find_user(username: &str) -> Result<UserId, String>  {
     let f = std::fs::File::open("/etc/passwd")
         .map_err(|e| format!("Failed to open password file: {:?}", e))?;
@@ -143,7 +143,7 @@ pub fn find_user(username: &str) -> Result<UserId, String>  {
 * However, `String`y based errors are a code smell
 * Prefer idiomatic error types that use `enum`s:
 
-```rust [9], ignore
+```rust, ignore
 enum MyError {
     BadPassword(String),
     IncorrectID,
@@ -168,7 +168,7 @@ pub fn find_user(username: &str) -> Result<UserId, MyError>  {
 
 ## When to not `?`: Before
 
-```rust [], ignore
+```rust, ignore
 for stream in tcp_listener.incoming() {
     // Should I use `stream?` here?
     // No, because my whole server would stop accepting connections
@@ -181,7 +181,7 @@ for stream in tcp_listener.incoming() {
 
 ## When to not `?`: After
 
-```rust [], ignore
+```rust, ignore
 if let (Ok(a), Ok(b)) = (job_a(), job_b()) {
     // run this code only when both jobs succeeded
 }
@@ -196,7 +196,7 @@ if let (Ok(a), Ok(b)) = (job_a(), job_b()) {
 * Iterators usually just care about processing or finding certain elements and throwing out the uninteresting data
 * Use `.filter_map()` for this:
 
-```rust [], ignore
+```rust, ignore
 let a = ["1", "two", "NaN", "four", "5"];
 
 // I don't care about bad results, I filter them out
@@ -217,7 +217,7 @@ let mut iter = a.iter()
 * `Option` and `Result` support transposition: they can wrap collections or be elements of them
 * If you want to process each error separately, use `Vec<Result<T, _>>`:
 
-```rust [], ignore
+```rust, ignore
 let vec_of_results: Vec<Result<i32, _>> = inputs.iter()
     .map(|s| s.parse::<i32>())
     .collect();
@@ -227,7 +227,7 @@ let vec_of_results: Vec<Result<i32, _>> = inputs.iter()
 
 * If you only care about all of them succeeding, you can `.collect()` them into a `Result<Vec<i32>, _>`:
 
-```rust [], ignore
+```rust, ignore
 let result_of_vec: Result<Vec<i32>, _> = inputs.iter()
     .map(|s| s.parse::<i32>())
     .collect()?;

--- a/training-slides/src/design-patterns.md
+++ b/training-slides/src/design-patterns.md
@@ -41,7 +41,7 @@ fn main() {
 
 ## Pattern: What does `?` do?
 
-```rust []
+```rust
 use std::fs::File;
 use std::io::{self, Write};
 
@@ -81,7 +81,7 @@ Reference-to-reference-conversion. Indicates that a type can easily produce refe
 
 ## Pattern: `AsRef<T>` - Example
 
-```rust []
+```rust
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
@@ -104,7 +104,7 @@ fn open_file<P: AsRef<Path>>(p: &P) {
 - An associated function to construct new "instances".
 - Use [`Default` trait](https://doc.rust-lang.org/stable/std/default/trait.Default.html). Try using `#[derive(Default)]` first.
 
-```rust []
+```rust
 pub struct Stuff {
     value: i64,
 }
@@ -123,7 +123,7 @@ impl Stuff {
 - Especially for Types that should be similar to other Types.
 - Also used to `impl` external Traits on external Types
 
-```rust []
+```rust
 struct MyString(String);
 
 impl MyString {
@@ -136,7 +136,7 @@ impl MyString {
 - Recall that at least one of Trait or Type should be local to `impl`.
 - This pattern allows you to extend external Type using a local Trait.
 
-```rust []
+```rust
 trait VecExt {
     fn magic_number(&self) -> usize;
 }

--- a/training-slides/src/documentation.md
+++ b/training-slides/src/documentation.md
@@ -36,7 +36,7 @@ It starts with some examples, then lists any `struct`s, traits, or functions the
 
 `//!` and `///` comments are read as Markdown.
 
-```rust []
+```rust
 //! Module documentation. (e.g. the 'Examples' part of `std::vec`).
 
 /// Document functions, structs, traits and values.

--- a/training-slides/src/dynamic-dispatch.md
+++ b/training-slides/src/dynamic-dispatch.md
@@ -10,7 +10,7 @@ There's two approaches.
 
 If the number of possible choices is limited, an Enum can be used:
 
-```rust []
+```rust
 enum Operation {
     Get,
     Set(String),
@@ -28,7 +28,7 @@ fn execute(op: Operation) {
 
 ## Alternative Form
 
-```rust []
+```rust
 enum Operation {
     Get,
     Set(String),
@@ -112,7 +112,7 @@ See <https://godbolt.org/z/cheWrvM45>
 
 Closure traits are dyn-compatible.
 
-```rust []
+```rust
 fn factory() -> Box<dyn Fn(i32) -> i32> {
     let num = 5;
 
@@ -126,7 +126,7 @@ Any type that is `'static + Sized` implements [`std::any::Any`](https://doc.rust
 
 We can use this to ask "is this reference actually a reference to *this specific type*?"
 
-```rust []
+```rust
 fn print_if_string(value: &dyn std::any::Any) {
     if let Some(s) = value.downcast_ref::<String>() {
         println!("It's a string({}): '{}'", s.len(), s);

--- a/training-slides/src/error-handling.md
+++ b/training-slides/src/error-handling.md
@@ -58,7 +58,7 @@ It's so important, it is special-cased within the compiler so you can say `None`
 
 When the result of a function is *either* __Ok__, or some __Error__ value, we use `Result`:
 
-```rust []
+```rust
 enum MyError {
     BadHeader
 }

--- a/training-slides/src/ffi.md
+++ b/training-slides/src/ffi.md
@@ -42,7 +42,7 @@ CPUs have registers, and they have a pointer to the stack (in RAM)
 
 Where does this function find its arguments? Where does the return value go?
 
-```rust []
+```rust
 struct SomeStruct(u32, f64);
 
 fn hello(param1: i32, param2: f64) -> SomeStruct { todo!() }
@@ -62,7 +62,7 @@ There are no conversion costs moving from C to Rust or vice-versa
 
 We have this amazing Rust library, we want to use in our existing C project.
 
-```rust []
+```rust
 struct MagicAdder {
 	amount: u32
 }
@@ -90,7 +90,7 @@ impl MagicAdder {
 
 ## C-flavoured Rust Code
 
-```rust []
+```rust
 #[repr(C)]
 struct MagicAdder {
 	amount: u32
@@ -219,7 +219,7 @@ Disables some Rust naming lints
 unsigned int cool_library_function(const char* p);
 ```
 
-```rust []
+```rust
 use std::ffi::c_char; // also in core::ffi
 
 extern "C" {
@@ -313,7 +313,7 @@ fn main() {
 
 When not knowing (or caring) about internal layout, [opaque structs](https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs) can be used.
 
-```rust []
+```rust
 /// This is like a 'struct FoobarContext;' in C
 #[repr(C)]
 pub struct FoobarContext { _priv: [i32; 0] }

--- a/training-slides/src/generics.md
+++ b/training-slides/src/generics.md
@@ -8,7 +8,7 @@ Generics are fundamental for Rust.
 
 Structs can have type parameters.
 
-```rust []
+```rust
 struct Point<Precision> {
     x: Precision,
     y: Precision,
@@ -34,7 +34,7 @@ The part `<Precision>` introduces a *type parameter* called `Precision`. Often p
 
 Enums can have type parameters.
 
-```rust []
+```rust
 enum Either<T, X> {
     Left(T),
     Right(X),
@@ -53,7 +53,7 @@ What happens if I leave out the `<i32, f64>` specifier? What would type paramete
 
 Functions can have type parameters.
 
-```rust []
+```rust
 fn print_stuff<X>(value: X) {
     // What can you do with `value` here?
 }
@@ -65,7 +65,7 @@ Default bounds are `Sized`, so finding the size of the type is one thing that yo
 
 ## Generic Implementations
 
-```rust []
+```rust
 struct Vector<T> {
     x: T,
     y: T,
@@ -120,7 +120,7 @@ Are there some trait bounds we could place on `T` such that `T + T -> T` and `T 
 
 ## Adding Bounds - Example
 
-```rust []
+```rust
 trait HasArea {
     fn area(&self) -> f32;
 }
@@ -146,7 +146,7 @@ fn main() {
 
 ## Adding Bounds - Alt. Example
 
-```rust []
+```rust
 trait HasArea {
     fn area(&self) -> f32;
 }
@@ -185,7 +185,7 @@ the line.
 
 You can specify multiple bounds.
 
-```rust []
+```rust
 trait HasArea {
     fn area(&self) -> f32;
 }
@@ -212,7 +212,7 @@ fn main() {
 * The `impl Trait` syntax in argument position was just *syntactic sugar*.
 * (It does something special in the return position though)
 
-```rust []
+```rust
 trait HasArea {
     fn area_m2(&self) -> f64;
 }
@@ -243,7 +243,7 @@ Some types that cannot be written out, like the closure, can be expressed as ret
 
 In Rust 1.51, we gained the ability to be generic over *constant values* too.
 
-```rust []
+```rust
 struct Polygon<const SIDES: u8> {
     colour: u32
 }
@@ -268,7 +268,7 @@ values of that type at run-time - the constant is pasted in wherever it is used.
 
 Traits themselves can have type parameters too!
 
-```rust []
+```rust
 trait HasArea<T> {
     fn area(&self) -> T;
 }
@@ -297,7 +297,7 @@ fn main() {
 * Some bounds apply automatically
 * Special syntax to *turn them off*
 
-```rust []
+```rust
 fn print_debug<T: std::fmt::Debug + ?Sized>(value: &T) {
     println!("value is {:?}", value);
 }

--- a/training-slides/src/heap.md
+++ b/training-slides/src/heap.md
@@ -2,7 +2,7 @@
 
 ## Where do Rust variables live?
 
-```rust []
+```rust
 struct Square {
     width: f32
 }
@@ -23,7 +23,7 @@ Note:
 
 ## Let's see some addresses...
 
-```rust []
+```rust
 struct Square {
     width: f32
 }
@@ -93,7 +93,7 @@ Because `Box<T>`:
 
 The `Deref` and `DerefMut` trait implementations let us use a Box quite naturally:
 
-```rust []
+```rust
 fn main() {
     let x: Box<f64> = Box::new(1.0_f64);
     let y: f64 = x.sin() * 2.0;
@@ -111,7 +111,7 @@ fn main() {
 
 ## Boxed Traits
 
-```rust []
+```rust
 fn make_stuff(want_integer: bool) -> Box<dyn std::fmt::Debug> {
     if want_integer {
         Box::new(42_i32)
@@ -140,7 +140,7 @@ We have the *reference counted* `Rc<T>` type for that!
 
 ## Using `Rc<T>`
 
-```rust []
+```rust
 use std::rc::Rc;
 
 struct Point { x: i32, y: i32 }
@@ -177,7 +177,7 @@ because each will always have at least one owner (the other).
 
 NB: `Rc` allows *sharing*, but not *mutability*...
 
-```rust []
+```rust
 use std::rc::{Rc, Weak};
 
 struct Dog { name: String, owner: Weak<Human> }
@@ -213,7 +213,7 @@ Why do you want this structure? Because given some `&Dog` you might very well wa
 
 We have more on this later...
 
-```rust []
+```rust
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 

--- a/training-slides/src/imports-and-modules.md
+++ b/training-slides/src/imports-and-modules.md
@@ -35,7 +35,7 @@
 
 We've been using modules from the Rust Standard Library...
 
-```rust []
+```rust
 use std::fs;
 use std::io::prelude::*;
 
@@ -130,7 +130,7 @@ The example is from the Knurling tool [`probe-run`](https://github.com/knurling-
 
 Choosing whether to import the parent module, or each of the types contained within, is something of an art form.
 
-```rust []
+```rust
 use std::fs;
 use std::collections::VecDeque;
 use std::io::prelude::*;
@@ -140,7 +140,7 @@ use std::io::prelude::*;
 
 There's also a more compact syntax for imports.
 
-```rust []
+```rust
 use std::{fs, io::prelude::*};
 
 fn main() -> std::io::Result<()> {

--- a/training-slides/src/io.md
+++ b/training-slides/src/io.md
@@ -44,7 +44,7 @@ To provide a common API, Rust offers some basic abstractions:
 
 <https://doc.rust-lang.org/std/io/trait.Read.html>
 
-```rust []
+```rust
 use std::io::Result;
 
 pub trait Read {
@@ -90,7 +90,7 @@ See the [std::io::File docs](https://doc.rust-lang.org/std/fs/struct.File.html#i
   * Owns a `R: Read`, and `impl BufRead`
   * Has a buffer in RAM and reads in large-ish chunks
 
-```rust []
+```rust
 use std::io::BufRead;
 
 fn print_file() -> std::io::Result<()> {

--- a/training-slides/src/iterators.md
+++ b/training-slides/src/iterators.md
@@ -42,7 +42,7 @@ Technically, all iterators calculate things on-the-fly. Some own another iterato
 1. You need to make an iterator
 2. You need to pump it in a loop
 
-```rust []
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     let mut iterator = data.iter();
@@ -60,7 +60,7 @@ fn main() {
 
 Same thing, but with `while let`.
 
-```rust []
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     let mut iterator = data.iter();
@@ -74,7 +74,7 @@ fn main() {
 
 Same thing, but with `for`
 
-```rust []
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     // for <variable> in <iterator>
@@ -88,7 +88,7 @@ fn main() {
 
 Same thing, but we let `for` call `.into_iter()` for us.
 
-```rust []
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     // for <variable> in <implements IntoIterator>
@@ -124,7 +124,7 @@ digraph {
 
 If a `for` loop calls `.into_iter()` how did we get a borrowed iterator?
 
-```rust []
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     for item in &data {
@@ -138,7 +138,7 @@ fn main() {
 
 The `&` is load-bearing...
 
-```rust [1-9|2|3|4-5]
+```rust
 fn main() {
     let data = vec![1, 2, 3, 4, 5];
     let temp = &data;
@@ -226,7 +226,7 @@ Note:
 
 This style of code is idiomatic in Rust:
 
-```rust [1-13|1-8|3|4|5|6|7]
+```rust
 /// Sum the squares of the even numbers given
 fn process_data(data: &[u32]) -> u32 {
     data.iter()
@@ -250,7 +250,7 @@ Note:
 
 What really happened:
 
-```rust [1-13|1-8|3|4|5|6|7]
+```rust
 /// Sum the squares of the even numbers given
 fn process_data(data: &[u32]) -> u32 {
     let ref_iter = data.iter();

--- a/training-slides/src/lifetimes.md
+++ b/training-slides/src/lifetimes.md
@@ -271,7 +271,7 @@ This function body does not *force* the two inputs to live for the same amount o
 
 ## Example
 
-```rust []
+```rust
 fn coin_flip() -> bool { false }
 
 fn pick_one<'a>(s1: &'a str, s2: &'a str) -> &'a str {

--- a/training-slides/src/macros.md
+++ b/training-slides/src/macros.md
@@ -29,7 +29,7 @@ Macros can be used to things such as:
 
 ## The `vec!` macro
 
-```rust [1-10|2-3|4-11]
+```rust
 fn main() {
     // You write:
     let v = vec![1, 2, 3];
@@ -48,7 +48,7 @@ fn main() {
 
 "Match zero or more expressions, and paste each into into a `temp_vec.push()` call"
 
-```rust [1-12|1|2|3|4-10|6-8]
+```rust
 #[macro_export]
 macro_rules! vec {
     ( $( $x:expr ),* ) => {

--- a/training-slides/src/methods-traits.md
+++ b/training-slides/src/methods-traits.md
@@ -10,7 +10,7 @@
 
 ## Example
 
-```rust []
+```rust
 struct Square(f64);
 
 impl Square {
@@ -73,7 +73,7 @@ This slide is only intended to show that there's lots of complexity behind the c
 * You call these with normal *function call* syntax.
 * Typically we provide a function called `new`
 
-```rust []
+```rust
 pub struct Square(f64);
 
 impl Square {
@@ -96,7 +96,7 @@ Question - can anyone just call `Square(5.0)` instead of `Square::new(5.0)`? Eve
 
 `impl` blocks can also have `const` values:
 
-```rust []
+```rust
 pub struct Square(f64);
 
 impl Square {
@@ -115,7 +115,7 @@ impl Square {
 * A trait is a list of methods and functions that a type must have.
 * A trait can provide *default* implementations if desired.
 
-```rust []
+```rust
 trait HasArea {
     /// Get the area, in m².
     fn area_m2(&self) -> f64;
@@ -129,7 +129,7 @@ trait HasArea {
 
 ## An example
 
-```rust []
+```rust
 trait HasArea {
     fn area_m2(&self) -> f64;
 }
@@ -233,7 +233,7 @@ The I/O traits do this.
 
 ## Using Traits Statically: Example
 
-```rust []
+```rust
 trait HasArea {
     fn area_m2(&self) -> f64;
 }
@@ -266,7 +266,7 @@ The total function says "I will give you a value you can display (with `println`
 
 ## Using Traits Dynamically: Example
 
-```rust []
+```rust
 trait HasArea {
     fn area_m2(&self) -> f64;
 }
@@ -300,7 +300,7 @@ In earlier editions, it was just `&Trait`, [but it was changed to `&dyn Trait`](
 
 * Traits can also *require* other traits to also be implemented
 
-```rust []
+```rust
 trait Printable: std::fmt::Debug { 
     fn print(&self) {
         println!("I am {:?}", self);

--- a/training-slides/src/overview.md
+++ b/training-slides/src/overview.md
@@ -2,7 +2,7 @@
 
 ---
 
-```rust []
+```rust
 fn main() {
     let random_number = generate_random_number();
     let mut my_choice = 10;

--- a/training-slides/src/ownership.md
+++ b/training-slides/src/ownership.md
@@ -19,7 +19,7 @@ Ownership is the basis for the memory management of Rust.
 
 ## Example
 
-```rust [1-9|2|3|7-9|4]
+```rust
 fn main() {
     let s = String::from("Hello 😀");
     print_string(s);
@@ -120,7 +120,7 @@ pointers may or may not be, depending on what they point at.
 
 ## Making a Reference
 
-```rust []
+```rust
 fn main() {
     let s = String::from("Hello 😀");
     // A reference to a String
@@ -177,7 +177,7 @@ fn print_string(s: &String) {
 
 ## Making an Exclusive Reference
 
-```rust []
+```rust
 fn main() {
     let mut s = String::from("Hello 😀");
     let s_ref = &mut s;
@@ -201,7 +201,7 @@ fn add_excitement(s: &mut String) {
 
 ## Full Example
 
-```rust []
+```rust
 fn main() {
     let mut s = String::from("Hello 😀");
     add_excitement(&mut s);
@@ -238,7 +238,7 @@ Why are there two types of Borrowed string types (`&String` and `&str`)? The fir
 * The first argument of the method is either `self`, `&self` or `&mut self`
 * They are converted to function calls by the compiler
 
-```rust []
+```rust
 fn main() {
     let mut s = String::from("Hello 😀");
     // This method call...
@@ -266,7 +266,7 @@ Some types have a `.clone()` method.
 
 It makes a new object, which looks just like the original object.
 
-```rust []
+```rust
 fn main() {
     let s = String::from("Hello 😀");
     let mut s_clone = s.clone();
@@ -282,7 +282,7 @@ You can mark your `struct` or `enum` with `#[derive(Clone)]`
 
 (But only if every value in your `struct`/`enum` itself is `Clone`)
 
-```rust []
+```rust
 #[derive(Clone)]
 struct Square {
     width: i32
@@ -300,7 +300,7 @@ fn main() {
 * Compiler copies these objects automatically
 * If cloning is very cheap, you could make your type `Copy`
 
-```rust []
+```rust
 fn main() {
     let x = 6;
     do_stuff(x);
@@ -328,7 +328,7 @@ You can define a specific behaviour to happen on *drop* using the *Drop* trait (
 
 For example, the memory used by a `String` is freed when dropped:
 
-```rust []
+```rust
 fn main() {
     // String created here (some memory is allocated on the heap)
     let s = String::from("Hello 😀");

--- a/training-slides/src/pac-svd2rust.md
+++ b/training-slides/src/pac-svd2rust.md
@@ -106,7 +106,7 @@ svd2rust (later) generates structures that look like this.
 
 ## Access via functions
 
-```rust []
+```rust
 pub struct Uart { base: *mut u32 } // now has no fields
 
 impl Uart {
@@ -134,7 +134,7 @@ The pointer is a `*mut u32` so the offsets are all in 32-bit words, not bytes.
 
 ## Access via functions (with ZSTs)
 
-```rust []
+```rust
 pub struct Uart<const ADDR: usize> {}
 
 impl<const ADDR: usize> Uart<ADDR> {
@@ -331,7 +331,7 @@ Chiptool is used by the embassy project.
 
 The [`derive-mmio`](https://docs.rs/derive-mmio) crate is from Knurling.
 
-```rust []
+```rust,ignore
 #[derive(derive_mmio::Mmio)]
 #[repr(C)]
 struct Registers {
@@ -360,7 +360,7 @@ references (writes and non-pure reads require `&mut self`).
 
 The [`safe-mmio`](https://docs.rs/safe-mmio) crate is from Google.
 
-```rust []
+```rust,ignore
 #[repr(C)]
 use safe_mmio::{ReadWrite, ReadPureWrite, ReadPure, UniqueMmioPointer, field};
 

--- a/training-slides/src/safety-performance-productivity.md
+++ b/training-slides/src/safety-performance-productivity.md
@@ -51,7 +51,7 @@ This is trivial to do in C++ and causes silent corruption.
 
 ## Iter Example (fixed)
 
-```rust []
+```rust
 /// Adds 0x00 padding for every 0xCC found
 fn process(data: &mut Vec<u8>) {
     let padding_byte_count = data.iter().filter(|&&x| x == 0xCC).count();
@@ -99,7 +99,7 @@ Note:
 
 ## Thread Example (Fixed)
 
-```rust []
+```rust
 use std::sync::atomic::{AtomicU32, Ordering};
 fn main() {
     let total = AtomicU32::new(0);

--- a/training-slides/src/shared-mutability.md
+++ b/training-slides/src/shared-mutability.md
@@ -32,7 +32,7 @@ There is only *one* way to modify data through a `&T` reference:
 
 ## `UnsafeCell`
 
-```rust []
+```rust
 use std::cell::UnsafeCell;
 
 fn main() {
@@ -72,7 +72,7 @@ Ideally, we would have a `fn view(&self) -> &str` to return the content, and inc
 
 ## Without `Cell` s
 
-```rust []
+```rust
 #[derive(Debug, Default)]
 struct Post {
     content: String,
@@ -92,7 +92,7 @@ impl Post {
 
 This isn't ideal! `view` takes a `&mut self`, meaning this won't work:
 
-```rust []
+```rust
 fn main() {
     let post = Post { content: "Blah".into(), ..Post::default() };
     // This line is a compile error!
@@ -118,7 +118,7 @@ impl Post {
 
 ## Without `Cell`
 
-```rust []
+```rust
 fn main() {
     // We need to make the entire struct mutable!
     let mut post = Post { content: "Blah".into(), ..Post::default() };
@@ -147,7 +147,7 @@ impl Post {
 
 Let's see our previous example with `Cell`.
 
-```rust []
+```rust
 fn main() {
     let post = Post {
         content: "Blah".into(),
@@ -221,7 +221,7 @@ The borrow checking is deferred to *run-time*
 
 ## Using `RefCell`
 
-```rust []
+```rust
 use std::cell::RefCell;
  
 fn main() {
@@ -244,7 +244,7 @@ fn main() {
 
 Let's see our previous example with `RefCell`.
 
-```rust []
+```rust
 fn main() {
     let post = Post { content: "Blah".into(), ..Post::default() };
     println!("{}", post.view());

--- a/training-slides/src/spawning-threads.md
+++ b/training-slides/src/spawning-threads.md
@@ -46,7 +46,7 @@ where
 * You *could* pass a function to `std::thread::spawn`.
 * In almost all cases you pass a *closure*
 
-```rust []
+```rust
 use std::{thread, time};
 
 fn main() {
@@ -63,7 +63,7 @@ fn main() {
 
 There's no `void* p_context` argument, because *closures* can *close-over* local variables.
 
-```rust []
+```rust
 use std::thread;
 
 fn main() {
@@ -86,7 +86,7 @@ Try changing this *move* closure to a regular referencing closure.
 
 However, the thread might live forever...
 
-```rust []
+```rust
 use std::{sync::Mutex, thread};
 
 fn main() {
@@ -108,7 +108,7 @@ fn main() {
 
 If a thread can live forever, we need its context to live just as long.
 
-```rust []
+```rust
 use std::{sync::{Arc, Mutex}, thread};
 
 fn main() {
@@ -165,7 +165,7 @@ This clearly limits the visual scope of the `thread_buffer` variable, to match t
 
 As of 1.63, we can say the threads will all have ended before we carry on our calling function.
 
-```rust []
+```rust
 use std::{sync::Mutex, thread};
 
 fn main() {

--- a/training-slides/src/std-lib-tour.md
+++ b/training-slides/src/std-lib-tour.md
@@ -14,7 +14,7 @@ Zero-sized types are used to mark things that "act like" they own a `T`.
 
 These are useful for types which require markers, generics, or use unsafe code.
 
-```rust []
+```rust
 use std::marker::PhantomData;
 
 struct HttpRequest<ResponseValue> {
@@ -33,7 +33,7 @@ A process builder, providing fine-grained control over how a new process should 
 
 Used for interacting with other executables.
 
-```rust []
+```rust
 use std::process::Command;
 
 fn example() {
@@ -50,7 +50,7 @@ fn example() {
 
 Path handling and file manipulation.
 
-```rust []
+```rust
 use std::fs::{File, canonicalize};
 use std::io::Write;
 

--- a/training-slides/src/testing.md
+++ b/training-slides/src/testing.md
@@ -29,7 +29,7 @@ Tests typically end up in 1 of 4 possible locations:
 
 ## `tests` Submodule
 
-```rust []
+```rust
 enum Direction { North, South, East, West }
 
 fn is_north(dir: Direction) -> bool {
@@ -69,7 +69,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ## Documentation Tests
 
-```rust []
+```rust
 /// ```rust
 /// use example::Direction;
 /// let way_home = Direction::North;

--- a/training-slides/src/type-state.md
+++ b/training-slides/src/type-state.md
@@ -121,7 +121,7 @@ the `new` functions you provide!
 
 ## Generic Pin Modes?
 
-```rust []
+```rust
 pub trait PinMode {}
 
 pub struct Output {}
@@ -158,7 +158,7 @@ let pin: Pin<OnFire> = ...;
 
 ## Sealing traits
 
-```rust []
+```rust
 mod private { pub trait Sealed {} }
 pub trait PinMode: private::Sealed {}
 

--- a/training-slides/src/unsafe.md
+++ b/training-slides/src/unsafe.md
@@ -58,7 +58,7 @@ Safe Rust is the worst language to implement linked lists. There's a full [text 
 
 Unsafe code must *always* be marked `unsafe`.
 
-```rust []
+```rust
 fn main() {
     let mut x = 1;
     let p = &raw mut x;
@@ -96,7 +96,7 @@ Rust allows you to shoot yourself in the foot, it just requires you to take your
 
 As Rust forbids aliasing, it is impossible in safe Rust to split a slice into 2 non-overlapping parts.
 
-```rust []
+```rust
 #[inline]
 fn split_at_mut<T>(value: &mut [T], mid: usize) -> (&mut [T], &mut [T]) {
     let len = value.len();


### PR DESCRIPTION
The [] for adding line numbers (or [5, 6] for adding progressive highlighting) was stopping mdbook from testing the code as it wasn't being detected as Rust code.