### PR TITLE
Update all criticalup.toml files to use Ferrocene 25.05

### DIFF
--- a/example-code/nrf52/criticalup.toml
+++ b/example-code/nrf52/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-24.11.0"
+release = "stable-25.05.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",

--- a/example-code/qemu-aarch32v8r/criticalup.toml
+++ b/example-code/qemu-aarch32v8r/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-25.02.0"
+release = "stable-25.05.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",

--- a/example-code/qemu-aarch64v8a/criticalup.toml
+++ b/example-code/qemu-aarch64v8a/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-24.11.0"
+release = "stable-25.05.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",

--- a/example-code/qemu-thumbv7em/criticalup.toml
+++ b/example-code/qemu-thumbv7em/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-24.11.0"
+release = "stable-25.05.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",


### PR DESCRIPTION
Ferrocene 25.05 is the next release - updating to check everything still works.