### PR TITLE
Switch to "latest 10.0" for Windows SDK

### DIFF
--- a/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
+++ b/example-code/native/ffi/use-rust-in-c/windows-example/windows-example.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{e78cb23e-7475-4424-b787-b262533d0805}</ProjectGuid>
     <RootNamespace>windowsexample</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Github no longer pre-installs what we had previously selected, causing CI to fail.

Fixes #319