### PR TITLE
Clean up .vscode settings

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Extra target for rustup to install"
     required: false
     default: ""
+  graphviz:
+    description: 'Install Graphviz'
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -26,6 +30,12 @@ runs:
         CRITICALUP_VERSION: ${{ inputs.criticalup }}
       run: |
         curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrocene/criticalup/releases/download/${CRITICALUP_VERSION}/criticalup-installer.sh | sh
+    - name: Install Graphviz (optional)
+      if: ${{ inputs.graphviz != '' }}
+      shell: bash
+      run: |
+        sudo apt -y update
+        sudo apt -y install graphviz
     - name: Install Just 1.42
       uses: extractions/setup-just@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           CRITICALUP_TOKEN: ${{ secrets.CRITICALUP_TOKEN }}
         run: |
          just ferrocene-qemu-aarch64v8a
+         just ferrocene-qemu-aarch64v8a-no-cargo
 
   ferrocene-qemu-aarch32v8r:
     name: Build qemu-aarch32v8r with Ferrocene

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+        with:
+          graphviz: true
       - uses: taiki-e/install-action@v2
         with:
           tool: mdbook@0.4.42,mdbook-graphviz@0.2.1
@@ -28,7 +30,6 @@ jobs:
           echo "Building with slug '${slug}'"
           echo "slug=${slug}" >> "${GITHUB_ENV}"
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrous-systems/mdslides/releases/download/v0.6.1/mdslides-installer.sh | sh
-          sudo apt-get update -y && sudo apt-get install -y graphviz
       - run: just assemble ${{ env.slug }}
       - uses: actions/upload-artifact@v4
         if: ${{success()}}
@@ -42,6 +43,19 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: ./rust-training-${{ env.slug }}.zip
+
+  test-book:
+    name: Test Book
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          graphviz: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook@0.4.42,mdbook-graphviz@0.2.1
+      - run: just test-book
 
   test-cheatsheets:
     name: Test Cheatsheets

--- a/example-code/nrf52/bsp_demo/.vscode/settings.json
+++ b/example-code/nrf52/bsp_demo/.vscode/settings.json
@@ -1,18 +1,4 @@
 {
-    // Configure rust-analyzer to use Ferrocene, via criticalup
-    "rust-analyzer.server.extraEnv": {
-        // Use these settings on macOS:
-        // "CARGO": "${userHome}/Library/Application Support/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/Library/Application Support/criticalup/bin/rustc",
-        // Use these settings on Linux:
-        // "CARGO": "${userHome}/.local/share/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/.local/share/criticalup/bin/rustc",
-        // Use these settings on Windows:
-        // "CARGO": "${userHome}/AppData/Roaming/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/AppData/Roaming/criticalup/bin/rustc",
-    },
-    // The proc-macro server is not supported in Ferrocene 25.02
-    // "rust-analyzer.procMacro.enable": false,
     // override the default setting (`cargo check --all-targets`) which produces the following error
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save

--- a/example-code/qemu-aarch32v8r/.vscode/settings.json
+++ b/example-code/qemu-aarch32v8r/.vscode/settings.json
@@ -1,18 +1,4 @@
 {
-    // Configure rust-analyzer to use Ferrocene, via criticalup
-    "rust-analyzer.server.extraEnv": {
-        // Use these settings on macOS:
-        // "CARGO": "${userHome}/Library/Application Support/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/Library/Application Support/criticalup/bin/rustc",
-        // Use these settings on Linux:
-        // "CARGO": "${userHome}/.local/share/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/.local/share/criticalup/bin/rustc",
-        // Use these settings on Windows:
-        // "CARGO": "${userHome}/AppData/Roaming/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/AppData/Roaming/criticalup/bin/rustc",
-    },
-    // The proc-macro server is not supported in Ferrocene 25.02
-    // "rust-analyzer.procMacro.enable": false,
     // override the default setting (`cargo check --all-targets`) which produces the following error
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save

--- a/example-code/qemu-aarch32v8r/README.md
+++ b/example-code/qemu-aarch32v8r/README.md
@@ -10,17 +10,13 @@ This repository contains a small example application that can be built using the
 
 Ferrocene 24.05 is supported on *x86-64 Linux (glibc)*
 (`x86_64-unknown-linux-gnu`) as the host platform, and *Armv8-A bare-metal*
-(`aarch64-unknown-none`) as a cross-compilation target. This demo uses the
-early-access 'experimental' *Aarch32 Armv8-R bare-metal* (`armv8r-none-eabihf`)
-target.
+(`aarch64-unknown-none`) as a cross-compilation target.
 
 You must first install Ferrocene by executing `criticalup install` inside this
 folder. This will require a valid CriticalUp token - please see the [CriticalUp
 documentation](https://criticalup.ferrocene.dev).
 
-To view the project inside VS Code, edit the
-[`.vscode/settings.json`](.vscode/settings.json) file to include the appropriate
-path to the criticalup proxy binaries.
+You should also run `criticalup link create` to set up `+ferrocene` as a valid option for `cargo`. The provided [`rust-toolchain.toml`](./rust-toolchain.toml) file assumes that this toolchain link exists within `rustup`.
 
 ## Demo contents
 

--- a/example-code/qemu-aarch32v8r/rust-toolchain.toml
+++ b/example-code/qemu-aarch32v8r/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# This file sets a rustup toolchain named 'ferrocene' to be the default
+#
+# For this to work, you should have criticalup version 1.5.1 or higher, 
+# and have run `criticalup link create`
+
+[toolchain]
+channel = "ferrocene"

--- a/example-code/qemu-aarch64v8a/.vscode/settings.json
+++ b/example-code/qemu-aarch64v8a/.vscode/settings.json
@@ -1,18 +1,4 @@
 {
-    // Configure rust-analyzer to use Ferrocene, via criticalup
-    "rust-analyzer.server.extraEnv": {
-        // Use these settings on macOS:
-        // "CARGO": "${userHome}/Library/Application Support/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/Library/Application Support/criticalup/bin/rustc",
-        // Use these settings on Linux:
-        // "CARGO": "${userHome}/.local/share/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/.local/share/criticalup/bin/rustc",
-        // Use these settings on Windows:
-        // "CARGO": "${userHome}/AppData/Roaming/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/AppData/Roaming/criticalup/bin/rustc",
-    },
-    // The proc-macro server is not supported in Ferrocene 25.02
-    // "rust-analyzer.procMacro.enable": false,
     // override the default setting (`cargo check --all-targets`) which produces the following error
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save

--- a/example-code/qemu-aarch64v8a/README.md
+++ b/example-code/qemu-aarch64v8a/README.md
@@ -16,12 +16,7 @@ You must first install Ferrocene by executing `criticalup install` inside this
 folder. This will require a valid CriticalUp token - please see the [CriticalUp
 documentation](https://criticalup.ferrocene.dev).
 
-To view the project inside VS Code, set your `RUSTC` environment variable to
-point at your `criticalup` rustc proxy. On macOS, that can be done with:
-
-```bash
-RUSTC=~/Library/Application\ Support/criticalup/bin/rustc code .
-```
+You should also run `criticalup link create` to set up `+ferrocene` as a valid option for `cargo`. The provided [`rust-toolchain.toml`](./rust-toolchain.toml) file assumes that this toolchain link exists within `rustup`.
 
 ## Demo contents
 

--- a/example-code/qemu-aarch64v8a/README.md
+++ b/example-code/qemu-aarch64v8a/README.md
@@ -83,9 +83,9 @@ This demo includes a [`build.sh`](./build.sh) shell script to build our binary
 by calling `rustc` directly. This script will:
 
 1. Find the location of the tools it needs
-2. Call `criticalup run rustc --crate-type=lib` repeatedly, to compile all the
+2. Call `rustc --crate-type=lib` repeatedly, to compile all the
    various dependencies (from the `./vendor` folder)
-3. Call `criticalup run rustc --crate-type=bin` to compile `src/bin/no_heap.rs`
+3. Call `rustc --crate-type=bin` to compile `src/bin/no_heap.rs`
    into `<output>/no_heap`
 4. Generate `asm` and `map` files from the `<output>/no_heap` binary using LLVM
    tools shipped with Ferrocene
@@ -126,6 +126,11 @@ Hello, this is Rust!
    10.00    20.00    30.00    40.00    50.00    60.00    70.00    80.00    90.00   100.00
 PANIC: PanicInfo { payload: Any { .. }, message: Some(I am a panic), location: Location { file: "src/bin/with_heap.rs", line: 61, col: 5 }, can_unwind: true, force_no_backtrace: false }
 ```
+
+This folder contains a `rust-toolchain.toml` file, so if you are using
+`rustup`, then `./build.sh` will automatically use Ferrocene. You can remove
+or modify the `rust-toolchain.toml` file if you wish to use a different Rust
+compiler, or you can set the `RUSTC` environment variable.
 
 Rather than type out the full QEMU command line, you can also use `qemu.sh`:
 

--- a/example-code/qemu-aarch64v8a/build.sh
+++ b/example-code/qemu-aarch64v8a/build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 TARGET_DIR=target/production
-RUSTC="${1:-rustc}"
+RUSTC="${RUSTC:-rustc}"
 SYSROOT=$("${RUSTC}" --print sysroot)
 OBJDUMP=$(ls "${SYSROOT}"/lib/rustlib/*/bin/llvm-objdump)
 RUSTC_FLAGS="--target aarch64-unknown-none -Copt-level=s"

--- a/example-code/qemu-aarch64v8a/rust-toolchain.toml
+++ b/example-code/qemu-aarch64v8a/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# This file sets a rustup toolchain named 'ferrocene' to be the default
+#
+# For this to work, you should have criticalup version 1.5.1 or higher, 
+# and have run `criticalup link create`
+
+[toolchain]
+channel = "ferrocene"

--- a/example-code/qemu-thumbv7em/.vscode/settings.json
+++ b/example-code/qemu-thumbv7em/.vscode/settings.json
@@ -1,18 +1,4 @@
 {
-    // Configure rust-analyzer to use Ferrocene, via criticalup
-    "rust-analyzer.server.extraEnv": {
-        // Use these settings on macOS:
-        // "CARGO": "${userHome}/Library/Application Support/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/Library/Application Support/criticalup/bin/rustc",
-        // Use these settings on Linux:
-        // "CARGO": "${userHome}/.local/share/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/.local/share/criticalup/bin/rustc",
-        // Use these settings on Windows:
-        // "CARGO": "${userHome}/AppData/Roaming/criticalup/bin/cargo",
-        // "RUSTC": "${userHome}/AppData/Roaming/criticalup/bin/rustc",
-    },
-    // The proc-macro server is not supported in Ferrocene 25.02
-    // "rust-analyzer.procMacro.enable": false,
     // override the default setting (`cargo check --all-targets`) which produces the following error
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save

--- a/example-code/qemu-thumbv7em/README.md
+++ b/example-code/qemu-thumbv7em/README.md
@@ -57,7 +57,7 @@ Alternatively, you can skip steps 2 and 3, and execute `criticalup run cargo run
 
 ## Running
 
-QEMU has been configured to redirect the UART data to a telnet server on `localhost:4321`. QEMU will therefore pause on start-up until you run `telnet localhost 4321` or similar.
+QEMU has been configured to redirect the UART data to a telnet server on `localhost:4321` so you can see the UART output separate from any `defmt` output. If QEMU pauses on start-up then it is waiting for you to run `telnet localhost 4321` to open a connection and start receiving the UART data.
 
 ## License
 

--- a/example-code/qemu-thumbv7em/README.md
+++ b/example-code/qemu-thumbv7em/README.md
@@ -39,6 +39,26 @@ The MPS-AN386 is described in Arm [Application Note AN386]. This image is based 
 
 [Application Note AN386]: https://developer.arm.com/documentation/dai0386/latest/
 
+## Ferrocene
+
+This project has been setup to build with the standard Rust Project toolchain. You can also build it with Ferrocene.
+
+Ferrocene 24.05 is supported on *x86-64 Linux (glibc)*
+(`x86_64-unknown-linux-gnu`) as the host platform, and *Armv8-A bare-metal*
+(`aarch64-unknown-none`) as a cross-compilation target. To use Ferrocene with this project:
+
+1. Install Ferrocene by executing `criticalup install` inside this
+folder. This will require a valid CriticalUp token - please see the [CriticalUp
+documentation](https://criticalup.ferrocene.dev).
+2. Run `criticalup link create` to set up `+ferrocene` as a valid option for `cargo`.
+3. Copy [`rust-toolchain.hide.toml`](./rust-toolchain.hide.toml) to `rust-toolchain.toml` to set the default toolchain to be `+ferrocene`.
+
+Alternatively, you can skip steps 2 and 3, and execute `criticalup run cargo run`. However, if you have an editor open using Rust Analyzer it will continue to build the code in the background with the standard Rust Project toolchain, and this may cause conflicts.
+
+## Running
+
+QEMU has been configured to redirect the UART data to a telnet server on `localhost:4321`. QEMU will therefore pause on start-up until you run `telnet localhost 4321` or similar.
+
 ## License
 
 Licensed under either of

--- a/example-code/qemu-thumbv7em/qemu_run.sh
+++ b/example-code/qemu-thumbv7em/qemu_run.sh
@@ -12,7 +12,12 @@ MACHINE="-cpu cortex-m4 -machine mps2-an386"
 LOG_FORMAT='{[{L}]%bold} {s} {({ff}:{l:1})%dimmed}'
 echo "ELF_BINARY=$ELF_BINARY"
 shift
+if [ `basename $ELF_BINARY` != "defmt" ]; then
+   SERIAL_PORT="-serial telnet:localhost:4321,server,wait"
+else
+	SERIAL_PORT=""
+fi
 echo "Running on '$MACHINE'..."
 echo "------------------------------------------------------------------------"
-qemu-system-arm $MACHINE -semihosting-config enable=on,target=native -kernel $ELF_BINARY -serial telnet:localhost:4321,server,wait | defmt-print -e $ELF_BINARY $* --log-format="$LOG_FORMAT"
+qemu-system-arm $MACHINE -semihosting-config enable=on,target=native -kernel $ELF_BINARY $SERIAL_PORT | defmt-print -e $ELF_BINARY $* --log-format="$LOG_FORMAT"
 echo "------------------------------------------------------------------------"

--- a/example-code/qemu-thumbv7em/rust-toolchain.hide.toml
+++ b/example-code/qemu-thumbv7em/rust-toolchain.hide.toml
@@ -1,0 +1,9 @@
+# This file sets a rustup toolchain named 'ferrocene' to be the default
+#
+# For this to work, you should have criticalup version 1.5.1 or higher, 
+# and have run `criticalup link create`
+#
+# Rename to rust-toolchain.toml to activate
+
+[toolchain]
+channel = "ferrocene"

--- a/justfile
+++ b/justfile
@@ -90,13 +90,13 @@ build-nrf52-bsp-demo:
 	cd example-code/nrf52/bsp_demo && cargo build --release
 
 build-qemu-aarch32v8r:
-	cd example-code/qemu-aarch32v8r && RUSTC_BOOTSTRAP=1 cargo build --release -Zbuild-std=core,alloc
+	cd example-code/qemu-aarch32v8r && RUSTC_BOOTSTRAP=1 cargo +stable build --release -Zbuild-std=core,alloc
 
 build-qemu-aarch64v8a:
-	cd example-code/qemu-aarch64v8a && cargo build --release
+	cd example-code/qemu-aarch64v8a && cargo +stable build --release
 
 build-qemu-aarch64v8a-no-cargo:
-	cd example-code/qemu-aarch64v8a && ./build.sh
+	cd example-code/qemu-aarch64v8a && RUSTC=$(rustup which rustc --toolchain=stable) ./build.sh
 
 build-qemu-thumbv7em:
 	cd example-code/qemu-thumbv7em && cargo build --release
@@ -117,6 +117,12 @@ ferrocene-qemu-aarch64v8a:
 	cd example-code/qemu-aarch64v8a
 	criticalup install
 	criticalup run cargo build --release
+
+ferrocene-qemu-aarch64v8a-no-cargo:
+	#!/bin/sh
+	cd example-code/qemu-aarch64v8a
+	criticalup install
+	RUSTC=$(criticalup which rustc) ./build.sh
 
 ferrocene-qemu-aarch32v8r:
 	#!/bin/sh

--- a/training-slides/src/compound-types.md
+++ b/training-slides/src/compound-types.md
@@ -282,7 +282,7 @@ fn test_shape(shape: Shape) {
 
 Newer Rust versions (edition 2024) allow `if let` chaining, for example:
 
-```rust
+```rust,ignore
 enum Shape {
     Circle(i32),
     Rectangle(i32, i32),


### PR DESCRIPTION
Now we have `critical link`, this PR can clean up a few things.

1. The `.vscode/settings.json` block about changing your `RUSTC` etc variables is no longer required - the `rust-toolchain.toml` file can do this for us
2. I realised the `mdbook test` wasn't running and now it is
3. I made sure we build the AArch64 demo both with and without cargo, both with Ferrocene and upstream Rust
