### PR TITLE
Use patched mdbook.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           graphviz: true
-      - uses: taiki-e/install-action@v2
+      - run: curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ~/.cargo/bin/mdbook
+      - run: chmod a+x ~/.cargo/bin/mdbook
+      - name: Install mdbook-graphviz
+        uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.5.2,mdbook-graphviz@0.3.1
+          tool: mdbook-graphviz@0.3.1
       - run: |
           slug=$(./describe.sh "${GITHUB_REF}")
           echo "Building with slug '${slug}'"
@@ -52,9 +55,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           graphviz: true
-      - uses: taiki-e/install-action@v2
+      - run: curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ~/.cargo/bin/mdbook
+      - run: chmod a+x ~/.cargo/bin/mdbook
+      - name: Install mdbook-graphviz
+        uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.5.2,mdbook-graphviz@0.3.1
+          tool: mdbook-graphviz@0.3.1
       - run: just test-book
 
   test-cheatsheets:

--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -21,10 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install tools
+      - run: curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ~/.cargo/bin/mdbook
+      - run: chmod a+x ~/.cargo/bin/mdbook
+      - name: Install mdbook-graphviz
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.5.2,mdbook-graphviz@0.3.1
+          tool: mdbook-graphviz@0.3.1
 
       - uses: extractions/setup-just@v3
         with:

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,9 @@ if [ "$(uname)" == "Darwin" ]; then
         && mv ./mdslides-*/mdslides . \
         && rm -rf ./mdslides-*/ )
 else
-    ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    #./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    # This one carries a patch we want
+    ./mdbook --version || ( curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ./mdbook && chmod a+x ./mdbook )
     dot -V || ( curl -ssL https://github.com/restruct/dot-static/raw/refs/heads/master/x64/dot_static -o ./dot && chmod a+x ./dot )
     ./mdbook-graphviz --version || ( curl -sSL https://github.com/dylanowen/mdbook-graphviz/releases/download/v0.3.1/mdbook-graphviz_v0.3.1_x86_64-unknown-linux-musl.zip -o mdbook-graphviz.zip \
         && unzip mdbook-graphviz.zip \


### PR DESCRIPTION
Similar to https://github.com/ferrous-systems/rust-exercises/pull/284, switches to a patched mdbook to avoid issues with the table of contents.