### PR TITLE
Remove diagram from ToC.

### DIFF
--- a/training-slides/src/introduction.md
+++ b/training-slides/src/introduction.md
@@ -12,6 +12,8 @@ Most of our modules are available now (shown in green), but some are still in de
 
 ## Ferrous Systems' Rust Training Modules
 
+Our training courses have the following dependencies, in terms of content we can assume at least some knowledge of:
+
 ```dot process
 digraph {
     node [shape=record, width=1.5, fillcolor=green3, style=filled];


### PR DESCRIPTION
Adding a bit of text between the heading and the diagram stops it being stuck to the header and appearing in the ToC.