### PR TITLE
Fix last slide of async-building-blocks

### DIFF
--- a/training-slides/src/async-building-blocks.md
+++ b/training-slides/src/async-building-blocks.md
@@ -188,3 +188,4 @@ async fn main() {
 while let Some(item) = stream.next().await {
     //...
 }
+```


### PR DESCRIPTION
There's some missing triple ticks in the last slide of 

https://rust-training.ferrous-systems.com/latest/slides/async-building-blocks#/18

that breaks the code block.

Before, left, right, after:

<img width="1917" height="1116" alt="image" src="https://github.com/user-attachments/assets/54380103-b6d4-4314-9564-110a94e7e45d" />
