### PR TITLE
cold futures: speaker note

### DIFF
--- a/training-slides/src/async-building-blocks.md
+++ b/training-slides/src/async-building-blocks.md
@@ -2,14 +2,25 @@
 
 ## Async
 
-* Built from important "building blocks"
+* Built from various important building blocks
 * Futures, Tasks, Executors, Streams, and more
 
 ## Differences between async & sync
 
 * sync programming often has imperative behaviour
-* async programming is about constructing a process at runtime and then executing it
-* this process is called the "futures tree"
+* async programming is an abstraction that allows developers to define yield points where
+  the execution can be paused and later resumed
+
+Note:
+
+- Imperative: Statements in synchronous code are just executed step-by-step.
+
+## Async language support
+
+* `async` functions can define yield points where the execution can be paused, represented by
+  `.await` syntax.
+* Built into the language: The compiler generates the state machines required to do this
+  automatically.
 
 ## An async Rust function
 
@@ -25,7 +36,12 @@ async fn read_from_disk(path: &str) -> std::io::Result<String> {
 }
 ```
 
-## (sketch) Desugaring return type
+Note:
+
+- function must be `async` so `await` can be used inside it.
+- The code between two `await`ion points has a regular synchronous flow.
+
+## (sketch) Desugaring the return type
 
 ```rust [], ignore
 use std::future::Future;
@@ -45,9 +61,14 @@ fn read_from_disk<'a>(path: &'a str)
 }
 ```
 
+Note:
+
+- Helpful mental model: A `async` function is a regular synchronous functions that returns a `Future`.
+
 ## What are Futures
 
-Futures represent a datastructure that - at some point in the future - give us the value that we are waiting for. The Future may be:
+Futures represent a datastructure that - at some point in the future - give us the value that we
+are waiting for. The Future may be:
 
 * delayed
 * immediate
@@ -63,9 +84,17 @@ Examples:
 * `read_to_end`: Read a complete input stream
 * `connect`: Connect a socket
 
+Note:
+
+- A future can be resolved or polled to completion, or canceled by `drop`ing them.
+
 ## Futures are poll-based
 
-They can be checked if they are _done_, and are usually mapped to readiness based APIs like `epoll`.
+They can be checked if they are _done_, and are usually mapped to readiness based APIs.
+Some examples:
+
+- On a UNIX based OS: Using the [`epoll`](https://man7.org/linux/man-pages/man7/epoll.7.html) mechanism.
+- On an Embedded ARM Cortex-M: Using architecture specific wakeup and sleep instructions.
 
 ## .await registers interest in completion
 
@@ -81,6 +110,11 @@ async fn read_from_disk(path: &str) -> std::io::Result<String> {
 }
 ```
 
+Note:
+
+- Reminder: `await` are the yield/pause points where the execution might be paused and later
+  resumed
+
 ## Futures are cold
 
 ```rust [], ignore
@@ -89,6 +123,12 @@ fn main() {
     let read_from_disk_future = read_from_disk();
 }
 ```
+
+Note:
+
+- You can still create objects that implement Future using a regular `fn` — for example, a `fn new`
+  constructor that returns a `Future`-implementing type. That synchronous function might do some
+  setup work.
 
 ## Futures need to be executed
 


### PR DESCRIPTION
In the embedded contexts, we can have futures that already start part of the work (e.g. UART transmission futures which loads the FIFO with the initial bytes). So those are not really "cold", or at the very least I think calling them "cold" is confusing.

Maybe we can just remove this? I think the knowledge that futures need to be executed/resolved is sufficient.